### PR TITLE
translate(06-github): translated setting up account to persian

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="" />
+    <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/book/06-github/sections/5-scripting.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/06-github/sections/5-scripting.asc" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -38,6 +41,17 @@
                 </list>
               </option>
               <option name="timestamp" value="1754988527286" />
+            </BranchCleanupEntry>
+            <BranchCleanupEntry>
+              <option name="deletions">
+                <list>
+                  <BranchDeletion>
+                    <option name="hash" value="b1ba38f91f7fb990cc697a13309e2737f65f4359" />
+                    <option name="name" value="book/translation/05-distributed-git" />
+                  </BranchDeletion>
+                </list>
+              </option>
+              <option name="timestamp" value="1755631405768" />
             </BranchCleanupEntry>
           </list>
         </option>
@@ -132,6 +146,9 @@
       <workItem from="1754736124061" duration="3674000" />
       <workItem from="1754985873748" duration="3567000" />
       <workItem from="1755502723693" duration="1436000" />
+      <workItem from="1755629596912" duration="2104000" />
+      <workItem from="1755677315267" duration="197000" />
+      <workItem from="1755679120902" duration="584000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/book/05-distributed-git/sections/maintaining.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/05-distributed-git/sections/maintaining.asc" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/book/06-github/sections/2-contributing.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/06-github/sections/2-contributing.asc" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -53,20 +53,16 @@
               <option name="branches">
                 <list>
                   <RecentBranch>
+                    <option name="branchName" value="book/translation/06-github" />
+                    <option name="lastUsedInstant" value="1755449148" />
+                  </RecentBranch>
+                  <RecentBranch>
                     <option name="branchName" value="book/translation/05-distributed-git" />
                     <option name="lastUsedInstant" value="1754727026" />
                   </RecentBranch>
                   <RecentBranch>
                     <option name="branchName" value="refactor/progit2" />
                     <option name="lastUsedInstant" value="1754726876" />
-                  </RecentBranch>
-                  <RecentBranch>
-                    <option name="branchName" value="book/translation/04-git-server" />
-                    <option name="lastUsedInstant" value="1754464303" />
-                  </RecentBranch>
-                  <RecentBranch>
-                    <option name="branchName" value="book/translation/03-git-branching" />
-                    <option name="lastUsedInstant" value="1754249158" />
                   </RecentBranch>
                   <RecentBranch>
                     <option name="branchName" value="master" />
@@ -95,24 +91,24 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;book/translation/05-distributed-git&quot;,
-    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/mac/Projects/WebstormProjects/Github/progit2-fa&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.keymap&quot;,
-    &quot;to.speed.mode.migration.done&quot;: &quot;true&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "git-widget-placeholder": "book/translation/06-github",
+    "junie.onboarding.icon.badge.shown": "true",
+    "last_opened_file_path": "/Users/mac/Projects/WebstormProjects/Github/progit2-fa",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "preferences.keymap",
+    "to.speed.mode.migration.done": "true",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="SharedIndexes">
     <attachedChunks>
       <set>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/book/06-github/sections/2-contributing.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/06-github/sections/2-contributing.asc" afterDir="false" />
-    </list>
+    <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -91,24 +89,24 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ModuleVcsDetector.initialDetectionPerformed": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "book/translation/06-github",
-    "junie.onboarding.icon.badge.shown": "true",
-    "last_opened_file_path": "/Users/mac/Projects/WebstormProjects/Github/progit2-fa",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "settings.editor.selected.configurable": "preferences.keymap",
-    "to.speed.mode.migration.done": "true",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;book/translation/06-github&quot;,
+    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/mac/Projects/WebstormProjects/Github/progit2-fa&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.keymap&quot;,
+    &quot;to.speed.mode.migration.done&quot;: &quot;true&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="SharedIndexes">
     <attachedChunks>
       <set>
@@ -133,6 +131,7 @@
       <workItem from="1754656446960" duration="3907000" />
       <workItem from="1754736124061" duration="3674000" />
       <workItem from="1754985873748" duration="3567000" />
+      <workItem from="1755502723693" duration="1436000" />
     </task>
     <servers />
   </component>

--- a/book/06-github/sections/1-setting-up-account.asc
+++ b/book/06-github/sections/1-setting-up-account.asc
@@ -1,97 +1,79 @@
-=== Account Setup and Configuration
+=== Account Setup and Configuration (راه‌اندازی و پیکربندی حساب کاربری)
 
 (((GitHub, user accounts)))
-The first thing you need to do is set up a free user account.
-Simply visit https://github.com[^], choose a user name that isn't already taken, provide an email address and a password, and click the big green "`Sign up for GitHub`" button.
+اولین کاری که باید انجام دهید، ایجاد یک حساب کاربری رایگان است. کافی است به https://github.com مراجعه کنید، یک نام کاربری که قبلاً استفاده نشده است انتخاب کنید، یک ایمیل و رمز عبور وارد کنید و روی دکمه بزرگ سبز رنگ «Sign up for GitHub» کلیک کنید.
 
 .The GitHub sign-up form
 image::images/signup.png[The GitHub sign-up form]
 
-The next thing you'll see is the pricing page for upgraded plans, but it's safe to ignore this for now.
-GitHub will send you an email to verify the address you provided.
-Go ahead and do this; it's pretty important (as we'll see later).
+مرحله بعدی صفحه قیمت‌گذاری طرح‌های ارتقا یافته است که فعلاً می‌توانید آن را نادیده بگیرید. گیت‌هاب ایمیلی برای تأیید آدرس ایمیل شما ارسال خواهد کرد. حتماً این کار را انجام دهید؛ این مرحله بسیار مهم است (که بعداً به آن خواهیم پرداخت).
 
 [NOTE]
 ====
-GitHub provides almost all of its functionality with free accounts, except some advanced features.
+گیت‌هاب تقریباً تمام امکانات خود را با حساب‌های رایگان ارائه می‌دهد، به جز برخی ویژگی‌های پیشرفته.
 
-GitHub's paid plans include advanced tools and features as well as increased limits for free services, but we won't be covering those in this book.
-To get more information about available plans and their comparison, visit https://github.com/pricing[^].
+طرح‌های پولی گیت‌هاب شامل ابزارها و امکانات پیشرفته به همراه افزایش محدودیت‌ها برای خدمات رایگان هستند، اما در این کتاب به آن‌ها نخواهیم پرداخت. برای کسب اطلاعات بیشتر درباره طرح‌های موجود و مقایسه آن‌ها، به https://github.com/pricing[^] مراجعه کنید.
 ====
 
-Clicking the Octocat logo at the top-left of the screen will take you to your dashboard page.
-You're now ready to use GitHub.
+کلیک روی لوگوی Octocat در بالای صفحه سمت چپ، شما را به صفحه داشبوردتان هدایت می‌کند. اکنون آماده استفاده از گیت‌هاب هستید.
 
-==== SSH Access
+==== SSH Access (دسترسی SSH)
 
 (((SSH keys, with GitHub)))
-As of right now, you're fully able to connect with Git repositories using the `https://` protocol, authenticating with the username and password you just set up.
-However, to simply clone public projects, you don't even need to sign up - the account we just created comes into play when we fork projects and push to our forks a bit later.
+در حال حاضر، شما می‌توانید با استفاده از پروتکل `https://` به مخازن گیت متصل شوید و با نام کاربری و رمز عبوری که همین الان ساخته‌اید، احراز هویت کنید. با این حال، برای کلون کردن پروژه‌های عمومی حتی نیازی به ثبت‌نام هم ندارید — حساب کاربری که ساختیم زمانی به کار می‌آید که بخواهیم پروژه‌ای را فورک کنیم و سپس تغییرات را به فورک خودمان ارسال کنیم.
 
-If you'd like to use SSH remotes, you'll need to configure a public key.
-If you don't already have one, see <<ch04-git-on-the-server#_generate_ssh_key>>.
-Open up your account settings using the link at the top-right of the window:
+اگر می‌خواهید از دسترسی SSH استفاده کنید، باید یک کلید عمومی تنظیم کنید. اگر هنوز کلیدی ندارید، به بخش <<ch04-git-on-the-server#_generate_ssh_key>> مراجعه کنید. تنظیمات حساب خود را از طریق لینک بالای سمت راست صفحه باز کنید:
 
 .The "`Account settings`" link
 image::images/account-settings.png[The “Account settings” link]
 
-Then select the "`SSH keys`" section along the left-hand side.
+سپس بخش "SSH keys" را از ستون سمت چپ انتخاب کنید.
 
 .The "`SSH keys`" link
 image::images/ssh-keys.png[The “SSH keys” link]
 
-From there, click the "`Add an SSH key`" button, give your key a name, paste the contents of your `~/.ssh/id_rsa.pub` (or whatever you named it) public-key file into the text area, and click "`Add key`".
+در آنجا روی دکمه «Add an SSH key» کلیک کنید، به کلید خود یک نام بدهید، محتوای فایل کلید عمومی خود مانند `~/.ssh/id_rsa.pub` (یا هر نامی که به آن داده‌اید) را در کادر متن قرار دهید و روی «Add key» کلیک کنید.
 
 [NOTE]
 ====
-Be sure to name your SSH key something you can remember.
-You can name each of your keys (e.g. "My Laptop" or "Work Account") so that if you need to revoke a key later, you can easily tell which one you're looking for.
+حتماً به کلید SSH خود نامی بدهید که بتوانید به راحتی به خاطر بسپارید. می‌توانید هر کلید را به نامی خاص مثل «لپ‌تاپ من» یا «حساب کاری» نام‌گذاری کنید تا اگر بعدها نیاز به لغو یک کلید داشتید، به راحتی متوجه شوید که کدام کلید را می‌خواهید حذف کنید.
 ====
 
 [[_personal_avatar]]
-==== Your Avatar
-
-Next, if you wish, you can replace the avatar that is generated for you with an image of your choosing.
-First go to the "`Profile`" tab (above the SSH Keys tab) and click "`Upload new picture`".
+==== Your Avatar (آواتار)
+اگر تمایل دارید، می‌توانید تصویری که به صورت پیش‌فرض برایتان ساخته شده را با عکس دلخواه خود جایگزین کنید. ابتدا به تب «Profile» (بالای تب SSH Keys) بروید و روی «Upload new picture» کلیک کنید.
 
 .The "`Profile`" link
 image::images/your-profile.png[The “Profile” link]
 
-We'll choose a copy of the Git logo that is on our hard drive and then we get a chance to crop it.
+ما یک کپی از لوگوی گیت که روی هارد داریم انتخاب می‌کنیم و سپس فرصت برش دادن تصویر را خواهیم داشت.
 
 .Crop your uploaded avatar
 image::images/avatar-crop.png[Crop your uploaded avatar]
 
-Now anywhere you interact on the site, people will see your avatar next to your username.
+از این پس، در هر جایی که در سایت فعالیت می‌کنید، دیگران آواتار شما را کنار نام کاربریتان خواهند دید.
 
-If you happen to have uploaded an avatar to the popular Gravatar service (often used for WordPress accounts), that avatar will be used by default and you don't need to do this step.
+اگر قبلاً تصویری در سرویس محبوب Gravatar (که اغلب برای حساب‌های وردپرس استفاده می‌شود) آپلود کرده باشید، آن تصویر به طور پیش‌فرض استفاده خواهد شد و نیازی به انجام این مرحله ندارید.
 
-==== Your Email Addresses
+==== Your Email Addresses (آدرس‌های ایمیل شما)
 
-The way that GitHub maps your Git commits to your user is by email address.
-If you use multiple email addresses in your commits and you want GitHub to link them up properly, you need to add all the email addresses you have used to the Emails section of the admin section.
+گیت‌هاب برای ثبت ارتباط کامیت‌های گیت با حساب شما از آدرس ایمیل استفاده می‌کند. اگر در کامیت‌های خود از چندین ایمیل استفاده می‌کنید و می‌خواهید گیت‌هاب آن‌ها را به درستی به حساب شما مرتبط کند، باید همه آدرس‌های ایمیل استفاده شده را در بخش Emails در تنظیمات حساب اضافه کنید.
 
 [[_add_email_addresses]]
 .Add all your email addresses
 image::images/email-settings.png[Add all your email addresses]
 
-In <<_add_email_addresses>> we can see some of the different states that are possible.
-The top address is verified and set as the primary address, meaning that is where you'll get any notifications and receipts.
-The second address is verified and so can be set as the primary if you wish to switch them.
-The final address is unverified, meaning that you can't make it your primary address.
-If GitHub sees any of these in commit messages in any repository on the site, it will be linked to your user now.
+در <<_add_email_addresses>> می‌توانید برخی از وضعیت‌های ممکن را ببینید. آدرس بالایی تأیید شده و به عنوان آدرس اصلی تنظیم شده است، یعنی اطلاعیه‌ها و رسیدها به آن ارسال می‌شود. آدرس دوم تأیید شده است و می‌توانید در صورت تمایل آن را به عنوان آدرس اصلی انتخاب کنید. آدرس آخر تأیید نشده است، بنابراین نمی‌توانید آن را به عنوان آدرس اصلی انتخاب کنید. اگر گیت‌هاب هر یک از این ایمیل‌ها را در پیام‌های کامیت در هر مخزن روی سایت ببیند، آن‌ها را به حساب شما پیوند خواهد داد.
 
-==== Two Factor Authentication
+==== Two Factor Authentication (احراز هویت دو مرحله‌ای)
 
-Finally, for extra security, you should definitely set up Two-factor Authentication or "`2FA`".
-Two-factor Authentication is an authentication mechanism that is becoming more and more popular recently to mitigate the risk of your account being compromised if your password is stolen somehow.
-Turning it on will make GitHub ask you for two different methods of authentication, so that if one of them is compromised, an attacker will not be able to access your account.
+در نهایت، برای امنیت بیشتر، حتماً باید احراز هویت دو مرحله‌ای یا «2FA» را فعال کنید. احراز هویت دو مرحله‌ای مکانیزمی است که اخیراً محبوبیت زیادی پیدا کرده تا ریسک هک شدن حساب در صورت لو رفتن رمز عبور را کاهش دهد. فعال کردن این ویژگی باعث می‌شود گیت‌هاب از شما دو روش مختلف احراز هویت بخواهد، به طوری که اگر یکی از آن‌ها درز کند، مهاجم نتواند به حساب شما دسترسی پیدا کند.
 
-You can find the Two-factor Authentication setup under the Security tab of your Account settings.
+تنظیمات احراز هویت دو مرحله‌ای را می‌توانید در تب Security در تنظیمات حساب خود بیابید.
 
 .2FA in the Security Tab
 image::images/2fa-1.png[2FA in the Security Tab]
 
-If you click on the "`Set up two-factor authentication`" button, it will take you to a configuration page where you can choose to use a phone app to generate your secondary code (a "`time based one-time password`"), or you can have GitHub send you a code via SMS each time you need to log in.
+اگر روی دکمه «Set up two-factor authentication» کلیک کنید، به صفحه‌ای هدایت می‌شوید که می‌توانید انتخاب کنید از اپلیکیشن تلفن همراه برای تولید کد ثانویه (یک «رمز عبور یک‌بارمصرف مبتنی بر زمان») استفاده کنید یا گیت‌هاب برای هر بار ورود، کد را از طریق پیامک ارسال کند.
 
-After you choose which method you prefer and follow the instructions for setting up 2FA, your account will then be a little more secure and you will have to provide a code in addition to your password whenever you log into GitHub.
+پس از انتخاب روش مورد نظر و دنبال کردن دستورالعمل‌ها برای راه‌اندازی 2FA، حساب شما کمی امن‌تر خواهد شد و هر بار که وارد گیت‌هاب می‌شوید، علاوه بر رمز عبور باید کد مربوطه را نیز وارد کنید.

--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -1,74 +1,74 @@
-=== Contributing to a Project
+=== Contributing to a Project (مشارکت در یک پروژه)
 
-Now that our account is set up, let's walk through some details that could be useful in helping you contribute to an existing project.
+حالا که حساب کاربری‌مان راه‌اندازی شده است، بیایید به جزئیاتی بپردازیم که می‌تواند در کمک به شما برای مشارکت در یک پروژه موجود مفید باشد.
 
-==== Forking Projects
+==== Forking Projects (فورک کردن پروژه‌ها)
 
 (((forking)))
-If you want to contribute to an existing project to which you don't have push access, you can "`fork`" the project.
-When you "`fork`" a project, GitHub will make a copy of the project that is entirely yours; it lives in your namespace, and you can push to it.
+اگر می‌خواهید در پروژه‌ای موجود مشارکت کنید که دسترسی ارسال (push) به آن را ندارید، می‌توانید پروژه را «`fork`» کنید.
+وقتی پروژه‌ای را «`fork`» می‌کنید، گیت‌هاب یک نسخه کپی از پروژه ایجاد می‌کند که کاملاً متعلق به شماست؛ این نسخه در فضای نام شما قرار دارد و می‌توانید به آن ارسال (push) انجام دهید.
 
 [NOTE]
 ====
-Historically, the term "`fork`" has been somewhat negative in context, meaning that someone took an open source project in a different direction, sometimes creating a competing project and splitting the contributors.
-In GitHub, a "`fork`" is simply the same project in your own namespace, allowing you to make changes to a project publicly as a way to contribute in a more open manner.
+تاریخچه اصطلاح «فورک» کمی منفی بوده است؛ به این معنا که کسی پروژه متن‌باز را به سمت مسیر متفاوتی برده و گاهی پروژه‌ای رقیب ایجاد کرده و مشارکت‌کنندگان را تقسیم کرده است.
+اما در گیت‌هاب، «`fork`» صرفاً همان پروژه در فضای نام شماست که به شما امکان می‌دهد به صورت عمومی تغییراتی در پروژه ایجاد کنید و به این ترتیب به شکلی بازتر مشارکت کنید.
 ====
 
-This way, projects don't have to worry about adding users as collaborators to give them push access.
-People can fork a project, push to it, and contribute their changes back to the original repository by creating what's called a Pull Request, which we'll cover next.
-This opens up a discussion thread with code review, and the owner and the contributor can then communicate about the change until the owner is happy with it, at which point the owner can merge it in.
+بدین ترتیب، پروژه‌ها نیازی به افزودن کاربران به عنوان همکار برای دادن دسترسی ارسال ندارند.
+افراد می‌توانند پروژه را فورک کنند، به آن ارسال انجام دهند و تغییرات خود را با ساختن چیزی به نام Pull Request به مخزن اصلی بازگردانند که در ادامه آن را بررسی خواهیم کرد.
+این کار یک رشته بحث با بازبینی کد ایجاد می‌کند و مالک پروژه و مشارکت‌کننده می‌توانند درباره تغییرات گفتگو کنند تا زمانی که مالک از آن رضایت داشته باشد و سپس آن را ادغام کند.
 
-To fork a project, visit the project page and click the "`Fork`" button at the top-right of the page.
+برای فورک کردن پروژه، به صفحه پروژه مراجعه کرده و روی دکمه «Fork» در بالای سمت راست صفحه کلیک کنید.
 
 .The "`Fork`" button
 image::images/forkbutton.png[The “Fork” button]
 
-After a few seconds, you'll be taken to your new project page, with your own writeable copy of the code.
+پس از چند ثانیه، به صفحه پروژه جدید خود هدایت می‌شوید که نسخه قابل نوشتن کد متعلق به خودتان است.
 
 [[ch06-github_flow]]
-==== The GitHub Flow
+==== The GitHub Flow (روند کاری گیت‌هاب)
 
 (((GitHub, Flow)))
-GitHub is designed around a particular collaboration workflow, centered on Pull Requests.
-This flow works whether you're collaborating with a tightly-knit team in a single shared repository, or a globally-distributed company or network of strangers contributing to a project through dozens of forks.
-It is centered on the <<ch03-git-branching#_topic_branch>> workflow covered in <<ch03-git-branching#ch03-git-branching>>.
+گیت‌هاب حول یک روند همکاری خاص طراحی شده است که مرکز آن Pull Requestها هستند.
+این روند چه در همکاری با تیمی کوچک در یک مخزن مشترک و چه در شرکتی جهانی یا شبکه‌ای از افراد ناشناس که از طریق ده‌ها فورک به پروژه‌ای مشارکت می‌کنند، کارآمد است.
+مرکز این روند، روش <<ch03-git-branching#_topic_branch>> است که در <<ch03-git-branching#ch03-git-branching>> شرح داده شده است.
 
-Here's how it generally works:
+روند کار معمولاً به این صورت است:
 
-1. Fork the project.
-2. Create a topic branch from `master`.
-3. Make some commits to improve the project.
-4. Push this branch to your GitHub project.
-5. Open a Pull Request on GitHub.
-6. Discuss, and optionally continue committing.
-7. The project owner merges or closes the Pull Request.
-8. Sync the updated `master` back to your fork.
+1. پروژه را فورک کنید.
+2. شاخه موضوعی (topic branch) از شاخه `master` بسازید.
+3. چند کامیت برای بهبود پروژه انجام دهید.
+4. این شاخه را به پروژه گیت‌هاب خود ارسال کنید.
+5. یک Pull Request روی گیت‌هاب باز کنید.
+6. در مورد آن بحث کنید و در صورت نیاز به ارسال کامیت‌های بیشتر ادامه دهید.
+7. مالک پروژه Pull Request را ادغام یا ببندد.
+8. شاخه `master` به‌روزشده را به فورک خود سینک کنید.
 
-This is basically the Integration Manager workflow covered in <<ch05-distributed-git#_integration_manager>>, but instead of using email to communicate and review changes, teams use GitHub's web based tools.
+این اساساً همان روند کاری Integration Manager است که در <<ch05-distributed-git#_integration_manager>> توضیح داده شده، با این تفاوت که به جای استفاده از ایمیل برای ارتباط و بررسی تغییرات، تیم‌ها از ابزارهای وب‌محور گیت‌هاب استفاده می‌کنند.
 
-Let's walk through an example of proposing a change to an open source project hosted on GitHub using this flow.
+بیایید یک مثال از پیشنهاد تغییر در یک پروژه متن‌باز میزبانی شده روی گیت‌هاب را با استفاده از این روند بررسی کنیم.
 
 [TIP]
 ====
-You can use the official *GitHub CLI* tool instead of the GitHub web interface for most things.
-The tool can be used on Windows, macOS, and Linux systems.
-Go to the https://cli.github.com/[GitHub CLI homepage^] for installation instructions and the manual.
+به جای استفاده از رابط وب گیت‌هاب، می‌توانید از ابزار رسمی *GitHub CLI* نیز استفاده کنید.
+این ابزار روی ویندوز، مک‌او‌اس و لینوکس قابل استفاده است.
+برای دستورالعمل نصب و راهنمای استفاده به https://cli.github.com/ مراجعه کنید.
 ====
 
-===== Creating a Pull Request
+===== Creating a Pull Request (ایجاد یک Pull Request)
 
-Tony is looking for code to run on his Arduino programmable microcontroller and has found a great program file on GitHub at https://github.com/schacon/blink[^].
+تونی به دنبال کدی برای اجرای روی میکروکنترلر برنامه‌پذیر Arduino خود است و برنامه بسیار خوبی در گیت‌هاب به آدرس https://github.com/schacon/blink پیدا کرده است.
 
 .The project we want to contribute to
 image::images/blink-01-start.png[The project we want to contribute to]
 
-The only problem is that the blinking rate is too fast.
-We think it's much nicer to wait 3 seconds instead of 1 in between each state change.
-So let's improve the program and submit it back to the project as a proposed change.
+تنها مشکلی که وجود دارد این است که نرخ چشمک زدن خیلی سریع است.
+ما فکر می‌کنیم بهتر است به جای ۱ ثانیه، بین هر تغییر حالت ۳ ثانیه صبر کنیم.
+پس بیایید برنامه را بهبود دهیم و آن را به عنوان یک تغییر پیشنهادی به پروژه ارسال کنیم.
 
-First, we click the 'Fork' button as mentioned earlier to get our own copy of the project.
-Our user name here is "`tonychacon`" so our copy of this project is at `https://github.com/tonychacon/blink` and that's where we can edit it.
-We will clone it locally, create a topic branch, make the code change and finally push that change back up to GitHub.
+ابتدا، همانطور که پیش‌تر گفته شد، روی دکمه «Fork» کلیک می‌کنیم تا نسخه خودمان از پروژه را داشته باشیم.
+نام کاربری ما در اینجا «tonychacon» است، پس نسخه ما از این پروژه در آدرس `https://github.com/tonychacon/blink` قرار دارد و می‌توانیم آن را ویرایش کنیم.
+ما آن را به صورت محلی کلون می‌کنیم، یک شاخه موضوعی می‌سازیم، تغییر در کد را انجام می‌دهیم و در نهایت آن را به گیت‌هاب ارسال می‌کنیم.
 
 [source,console]
 ----
@@ -113,135 +113,127 @@ To https://github.com/tonychacon/blink
  * [new branch]      slow-blink -> slow-blink
 ----
 
-<1> Clone our fork of the project locally.
-<2> Create a descriptive topic branch.
-<3> Make our change to the code.
-<4> Check that the change is good.
-<5> Commit our change to the topic branch.
-<6> Push our new topic branch back up to our GitHub fork.
+<1> فورک پروژه را به صورت محلی کلون کنیم.
+<2> یک شاخه موضوعی با نام توصیفی بسازیم.
+<3> تغییر مورد نظر را در کد اعمال کنیم.
+<4> مطمئن شویم که تغییر خوب است.
+<5> تغییر را به شاخه موضوعی کامیت کنیم.
+<6> شاخه موضوعی جدید را به فورک گیت‌هاب خود ارسال کنیم.
 
-Now if we go back to our fork on GitHub, we can see that GitHub noticed that we pushed a new topic branch up and presents us with a big green button to check out our changes and open a Pull Request to the original project.
+حالا اگر به فورک خود در گیت‌هاب برگردیم، می‌بینیم که گیت‌هاب متوجه شده شاخه موضوعی جدیدی ارسال کرده‌ایم و دکمه بزرگی به رنگ سبز برای بررسی تغییرات و باز کردن Pull Request به پروژه اصلی به ما نشان می‌دهد.
 
-You can alternatively go to the "`Branches`" page at `\https://github.com/<user>/<project>/branches` to locate your branch and open a new Pull Request from there.
+همچنین می‌توانید به صفحه «`Branches`» در آدرس `https://github.com/<user>/<project>/branches` بروید، شاخه خود را پیدا کنید و از آنجا Pull Request جدید باز کنید.
 
 .Pull Request button
 image::images/blink-02-pr.png[Pull Request button]
 
 (((GitHub, pull requests)))
-If we click that green button, we'll see a screen that asks us to give our Pull Request a title and description.
-It is almost always worthwhile to put some effort into this, since a good description helps the owner of the original project determine what you were trying to do, whether your proposed changes are correct, and whether accepting the changes would improve the original project.
+اگر روی آن دکمه سبز کلیک کنیم، صفحه‌ای ظاهر می‌شود که از ما می‌خواهد عنوان و توضیحی برای Pull Request خود بنویسیم.
+تقریباً همیشه ارزش دارد که برای این کار وقت بگذارید، چون توضیح خوب به مالک پروژه اصلی کمک می‌کند بفهمد هدف شما چیست، آیا تغییرات پیشنهادی درست هستند و آیا پذیرفتن آن‌ها پروژه اصلی را بهتر می‌کند یا خیر.
 
-We also see a list of the commits in our topic branch that are "`ahead`" of the `master` branch (in this case, just the one) and a unified diff of all the changes that will be made should this branch get merged by the project owner.
+همچنین فهرستی از کامیت‌های شاخه موضوعی را می‌بینیم که نسبت به شاخه `master` «جلوتر» هستند (در این مورد فقط یک کامیت) و یک diff یکپارچه از تمام تغییراتی که در صورت ادغام این شاخه توسط مالک پروژه اعمال خواهند شد.
 
 .Pull Request creation page
 image::images/blink-03-pull-request-open.png[Pull Request creation page]
 
-When you hit the 'Create pull request' button on this screen, the owner of the project you forked will get a notification that someone is suggesting a change and will link to a page that has all of this information on it.
+وقتی روی دکمه «Create pull request» در این صفحه کلیک می‌کنید، صاحب پروژه‌ای که آن را فورک کرده‌اید، اطلاع دریافت می‌کند که کسی تغییراتی را پیشنهاد داده است و به صفحه‌ای لینک می‌شود که تمام این اطلاعات را دارد.
 
 [NOTE]
 ====
-Though Pull Requests are used commonly for public projects like this when the contributor has a complete change ready to be made, it's also often used in internal projects _at the beginning_ of the development cycle.
-Since you can keep pushing to the topic branch even *after* the Pull Request is opened, it's often opened early and used as a way to iterate on work as a team within a context, rather than opened at the very end of the process.
+اگرچه درخواست‌های pull معمولاً برای پروژه‌های عمومی مانند این استفاده می‌شوند وقتی که مشارکت‌کننده تغییر کاملی آماده کرده است، اما اغلب در پروژه‌های داخلی _در ابتدای_ چرخه توسعه هم استفاده می‌شوند.
+از آنجا که می‌توانید حتی *بعد از* باز شدن درخواست pull به شاخه موضوعی، تغییرات جدید ارسال کنید، معمولاً این درخواست زود باز می‌شود و به عنوان راهی برای همکاری تیمی و انجام اصلاحات در یک زمینه مشخص استفاده می‌شود، نه اینکه در پایان فرایند باز شود.
 ====
 
-===== Iterating on a Pull Request
+===== Iterating on a Pull Request (تکرار و اصلاح روی یک Pull Request)
 
-At this point, the project owner can look at the suggested change and merge it, reject it or comment on it.
-Let's say that he likes the idea, but would prefer a slightly longer time for the light to be off than on.
+در این مرحله، صاحب پروژه می‌تواند تغییر پیشنهادی را بررسی کرده و آن را ادغام کند، رد کند یا نظر دهد.
+فرض کنیم او ایده را دوست دارد، اما ترجیح می‌دهد مدت زمان خاموش بودن چراغ کمی بیشتر از روشن بودن آن باشد.
 
-Where this conversation may take place over email in the workflows presented in <<ch05-distributed-git#ch05-distributed-git>>, on GitHub this happens online.
-The project owner can review the unified diff and leave a comment by clicking on any of the lines.
+جایی که این گفتگو ممکن است در ایمیل انجام شود، در جریان کاری که در <<ch05-distributed-git#ch05-distributed-git>> توضیح داده شده، در گیت‌هاب این تعامل به صورت آنلاین انجام می‌شود.
+صاحب پروژه می‌تواند تفاوت‌های یکپارچه شده (unified diff) را بررسی کرده و با کلیک روی هر خط، نظر خود را ثبت کند.
 
 .Comment on a specific line of code in a Pull Request
 image::images/blink-04-pr-comment.png[Comment on a specific line of code in a Pull Request]
 
-Once the maintainer makes this comment, the person who opened the Pull Request (and indeed, anyone else watching the repository) will get a notification.
-We'll go over customizing this later, but if he had email notifications turned on, Tony would get an email like this:
+وقتی نگهدارنده پروژه این نظر را ثبت کند، فردی که درخواست pull را باز کرده (و در واقع هر کسی که مخزن را دنبال می‌کند) یک اطلاعیه دریافت خواهد کرد.
+بعداً درباره تنظیمات سفارشی این اطلاعیه‌ها صحبت خواهیم کرد، اما اگر او اعلان‌های ایمیلی را فعال کرده باشد، تونی ایمیلی شبیه این دریافت می‌کند:
 
 [[_email_notification]]
 .Comments sent as email notifications
 image::images/blink-04-email.png[Comments sent as email notifications]
 
-Anyone can also leave general comments on the Pull Request.
-In <<_pr_discussion>> we can see an example of the project owner both commenting on a line of code and then leaving a general comment in the discussion section.
-You can see that the code comments are brought into the conversation as well.
+هر کسی همچنین می‌تواند نظر کلی درباره درخواست pull بگذارد.
+در <<_pr_discussion>> مثالی می‌بینیم که صاحب پروژه هم روی یک خط کد نظر می‌دهد و سپس در بخش بحث نظر کلی می‌گذارد.
+می‌توانید ببینید که نظرات کد نیز در گفتگو وارد شده‌اند.
 
 [[_pr_discussion]]
 .Pull Request discussion page
 image::images/blink-05-general-comment.png[Pull Request discussion page]
 
-Now the contributor can see what they need to do in order to get their change accepted.
-Luckily this is very straightforward.
-Where over email you may have to re-roll your series and resubmit it to the mailing list, with GitHub you simply commit to the topic branch again and push, which will automatically update the Pull Request.
-In <<_pr_final>> you can also see that the old code comment has been collapsed in the updated Pull Request, since it was made on a line that has since been changed.
+حالا مشارکت‌کننده می‌تواند ببیند برای پذیرفته شدن تغییرش چه کاری باید انجام دهد.
+خوشبختانه این کار بسیار ساده است.
+جایی که در ایمیل ممکن است مجبور باشید سری تغییرات خود را بازنویسی و مجدداً ارسال کنید، در گیت‌هاب فقط کافی است دوباره روی شاخه موضوعی commit کرده و push کنید که به طور خودکار درخواست pull را به‌روزرسانی می‌کند.
+در <<_pr_final>> نیز می‌توانید ببینید که نظر قدیمی روی کد در درخواست pull به‌روزرسانی شده جمع شده است، چون روی خطی گذاشته شده بود که بعداً تغییر کرده است.
 
-Adding commits to an existing Pull Request doesn't trigger a notification, so once Tony has pushed his corrections he decides to leave a comment to inform the project owner that he made the requested change.
+افزودن commit به یک درخواست pull موجود اعلان جدیدی ایجاد نمی‌کند، بنابراین وقتی تونی اصلاحات خود را push می‌کند، تصمیم می‌گیرد نظری بگذارد تا به صاحب پروژه اطلاع دهد که تغییر خواسته شده اعمال شده است.
 
 [[_pr_final]]
 .Pull Request final
 image::images/blink-06-final.png[Pull Request final]
 
-An interesting thing to notice is that if you click on the "`Files Changed`" tab on this Pull Request, you'll get the "`unified`" diff -- that is, the total aggregate difference that would be introduced to your main branch if this topic branch was merged in.
-In `git diff` terms, it basically automatically shows you `git diff master...<branch>` for the branch this Pull Request is based on.
-See <<ch05-distributed-git#_what_is_introduced>> for more about this type of diff.
+یک نکته جالب این است که اگر روی تب «Files Changed» این درخواست pull کلیک کنید، «unified diff» را مشاهده می‌کنید — یعنی تفاوت کلی که در صورت ادغام این شاخه موضوعی، به شاخه اصلی اضافه خواهد شد.
+به زبان git diff، این تقریباً همان نمایش خودکار `git diff master...<branch>` برای شاخه‌ای است که این درخواست pull بر اساس آن است.
+برای اطلاعات بیشتر درباره این نوع diff به <<ch05-distributed-git#_what_is_introduced>> مراجعه کنید.
 
-The other thing you'll notice is that GitHub checks to see if the Pull Request merges cleanly and provides a button to do the merge for you on the server.
-This button only shows up if you have write access to the repository and a trivial merge is possible.
-If you click it GitHub will perform a "`non-fast-forward`" merge, meaning that even if the merge *could* be a fast-forward, it will still create a merge commit.
+موضوع دیگری که متوجه خواهید شد این است که گیت‌هاب بررسی می‌کند که آیا این درخواست pull به صورت تمیز قابل ادغام است یا نه و دکمه‌ای برای ادغام روی سرور به شما ارائه می‌دهد.
+این دکمه فقط زمانی نمایش داده می‌شود که شما دسترسی نوشتن به مخزن داشته باشید و ادغام ساده‌ای ممکن باشد.
+اگر روی آن کلیک کنید، گیت‌هاب یک ادغام «non-fast-forward» انجام می‌دهد، یعنی حتی اگر ادغام می‌توانست fast-forward باشد، باز هم یک commit ادغام ایجاد خواهد کرد.
 
-If you would prefer, you can simply pull the branch down and merge it locally.
-If you merge this branch into the `master` branch and push it to GitHub, the Pull Request will automatically be closed.
+اگر ترجیح می‌دهید، می‌توانید شاخه را به صورت محلی pull کرده و ادغام کنید.
+اگر این شاخه را در شاخه `master` ادغام کنید و به گیت‌هاب push کنید، درخواست pull به طور خودکار بسته خواهد شد.
 
-This is the basic workflow that most GitHub projects use.
-Topic branches are created, Pull Requests are opened on them, a discussion ensues, possibly more work is done on the branch and eventually the request is either closed or merged.
+این جریان کاری پایه‌ای است که بیشتر پروژه‌های گیت‌هاب استفاده می‌کنند.
+شاخه‌های موضوعی ساخته می‌شوند، درخواست‌های pull روی آن‌ها باز می‌شود، بحثی شکل می‌گیرد، احتمالاً کار بیشتری روی شاخه انجام می‌شود و در نهایت درخواست بسته یا ادغام می‌شود.
 
 [NOTE]
 .Not Only Forks
 ====
-It's important to note that you can also open a Pull Request between two branches in the same repository.
-If you're working on a feature with someone and you both have write access to the project, you can push a topic branch to the repository and open a Pull Request on it to the `master` branch of that same project to initiate the code review and discussion process.
-No forking necessary.
+مهم است بدانید که می‌توانید درخواست pull را بین دو شاخه در یک مخزن نیز باز کنید.
+اگر با کسی روی یک ویژگی کار می‌کنید و هر دو دسترسی نوشتن به پروژه دارید، می‌توانید شاخه موضوعی را به مخزن push کنید و روی آن درخواست pull به شاخه `master` همان پروژه باز کنید تا فرایند بازبینی کد و بحث شروع شود.
+نیازی به فورک کردن نیست.
 ====
 
-==== Advanced Pull Requests
+==== Advanced Pull Requests (درخواست‌های پیشرفته برای ادغام)
 
-Now that we've covered the basics of contributing to a project on GitHub, let's cover a few interesting tips and tricks about Pull Requests so you can be more effective in using them.
+حالا که اصول اولیه مشارکت در یک پروژه در گیت‌هاب را پوشش دادیم، بیایید چند نکته و ترفند جالب درباره‌ی درخواست‌های ادغام را بررسی کنیم تا بتوانید استفاده موثرتری از آن‌ها داشته باشید.
 
-===== Pull Requests as Patches
+===== Pull Requests as Patches (درخواست‌های ادغام به عنوان پچ‌ها)
 
-It's important to understand that many projects don't really think of Pull Requests as queues of perfect patches that should apply cleanly in order, as most mailing list-based projects think of patch series contributions.
-Most GitHub projects think about Pull Request branches as iterative conversations around a proposed change, culminating in a unified diff that is applied by merging.
+مهم است که بدانید بسیاری از پروژه‌ها درخواست‌های ادغام را به عنوان صفی از پچ‌های کامل و بدون نقص که باید به ترتیب و بدون خطا اعمال شوند، نمی‌بینند، برخلاف پروژه‌های مبتنی بر فهرست‌های پستی که سری‌های پچ را به این شکل می‌بینند. بیشتر پروژه‌های گیت‌هاب شاخه‌های درخواست ادغام را به عنوان گفتگوهای تکرارشونده درباره‌ی یک تغییر پیشنهادی در نظر می‌گیرند که در نهایت به یک دیف متحد منجر می‌شود که با ادغام اعمال می‌شود.
 
-This is an important distinction, because generally the change is suggested before the code is thought to be perfect, which is far more rare with mailing list based patch series contributions.
-This enables an earlier conversation with the maintainers so that arriving at the proper solution is more of a community effort.
-When code is proposed with a Pull Request and the maintainers or community suggest a change, the patch series is generally not re-rolled, but instead the difference is pushed as a new commit to the branch, moving the conversation forward with the context of the previous work intact.
+این تفاوت مهمی است، زیرا معمولاً تغییر قبل از این که کد کامل و بی‌نقص باشد پیشنهاد می‌شود، چیزی که در مشارکت‌های سری‌های پچ مبتنی بر فهرست‌های پستی بسیار نادر است. این امکان گفتگوی زودتر با نگهدارندگان پروژه را فراهم می‌کند تا رسیدن به راه حل مناسب بیشتر یک تلاش جمعی باشد. وقتی کدی با یک درخواست ادغام پیشنهاد می‌شود و نگهداران یا جامعه تغییری را پیشنهاد می‌دهند، معمولاً سری پچ دوباره ارائه نمی‌شود، بلکه تفاوت به صورت یک کامیت جدید به شاخه اضافه می‌شود و گفتگو را با حفظ زمینه‌ی کار قبلی ادامه می‌دهد.
 
-For instance, if you go back and look again at <<_pr_final>>, you'll notice that the contributor did not rebase his commit and send another Pull Request.
-Instead they added new commits and pushed them to the existing branch.
-This way if you go back and look at this Pull Request in the future, you can easily find all of the context of why decisions were made.
-Pushing the "`Merge`" button on the site purposefully creates a merge commit that references the Pull Request so that it's easy to go back and research the original conversation if necessary.
+برای مثال، اگر دوباره به <<_pr_final>> نگاه کنید، متوجه می‌شوید که مشارکت‌کننده کامیت خود را ری‌بیس نکرده و درخواست ادغام جدیدی نفرستاده است. بلکه کامیت‌های جدیدی اضافه کرده و آن‌ها را به شاخه موجود پوش کرده است. بدین ترتیب اگر در آینده به این درخواست ادغام مراجعه کنید، می‌توانید به راحتی تمام زمینه‌ی تصمیم‌گیری‌ها را پیدا کنید. زدن دکمه «Merge» در سایت عمداً یک کامیت ادغام ایجاد می‌کند که به درخواست ادغام اشاره دارد تا در صورت نیاز به سادگی بتوان به گفتگوی اصلی بازگشت و آن را بررسی کرد.
 
-===== Keeping up with Upstream
+===== Keeping up with Upstream (به‌روز بودن با شاخه اصلی)
 
-If your Pull Request becomes out of date or otherwise doesn't merge cleanly, you will want to fix it so the maintainer can easily merge it.
-GitHub will test this for you and let you know at the bottom of every Pull Request if the merge is trivial or not.
+اگر درخواست ادغام شما قدیمی شود یا به هر دلیلی به‌طور تمیز ادغام نشود، باید آن را اصلاح کنید تا نگهدارنده بتواند به آسانی آن را ادغام کند. گیت‌هاب این موضوع را برای شما آزمایش می‌کند و در پایین هر درخواست ادغام به شما می‌گوید که ادغام ساده است یا خیر.
 
 [[_pr_fail]]
 .Pull Request does not merge cleanly
 image::images/pr-01-fail.png[Pull Request does not merge cleanly]
 
-If you see something like <<_pr_fail>>, you'll want to fix your branch so that it turns green and the maintainer doesn't have to do extra work.
+اگر درخواست ادغام شما قدیمی شود یا به هر دلیلی به‌طور تمیز ادغام نشود، باید آن را اصلاح کنید تا نگهدارنده بتواند به آسانی آن را ادغام کند. گیت‌هاب این موضوع را برای شما آزمایش می‌کند و در پایین هر درخواست ادغام به شما می‌گوید که ادغام ساده است یا خیر.
 
-You have two main options in order to do this.
-You can either rebase your branch on top of whatever the target branch is (normally the `master` branch of the repository you forked), or you can merge the target branch into your branch.
+اگر چیزی شبیه به <<_pr_fail>> دیدید، باید شاخه خود را اصلاح کنید تا به رنگ سبز در بیاید و نگهدارنده مجبور به انجام کار اضافی نشود.
 
-Most developers on GitHub will choose to do the latter, for the same reasons we just went over in the previous section.
-What matters is the history and the final merge, so rebasing isn't getting you much other than a slightly cleaner history and in return is *far* more difficult and error prone.
+برای این کار دو گزینه اصلی دارید. می‌توانید شاخه خود را روی شاخه هدف (معمولاً شاخه `master` مخزن فورک شده) ری‌بیس کنید یا شاخه هدف را در شاخه خود ادغام کنید.
 
-If you want to merge in the target branch to make your Pull Request mergeable, you would add the original repository as a new remote, fetch from it, merge the main branch of that repository into your topic branch, fix any issues and finally push it back up to the same branch you opened the Pull Request on.
+بیشتر توسعه‌دهندگان در گیت‌هاب گزینه دوم را انتخاب می‌کنند، به دلایلی که در بخش قبلی توضیح دادیم. آنچه اهمیت دارد تاریخچه و ادغام نهایی است، پس ری‌بیس کردن جز داشتن تاریخچه‌ای کمی مرتب‌تر، مزیت زیادی ندارد و در عوض بسیار دشوارتر و مستعد خطا است.
 
-For example, let's say that in the "`tonychacon`" example we were using before, the original author made a change that would create a conflict in the Pull Request.
-Let's go through those steps.
+اگر می‌خواهید شاخه هدف را ادغام کنید تا درخواست ادغام شما قابل ادغام شود، باید مخزن اصلی را به عنوان یک ریموت جدید اضافه کنید، از آن ریموت دریافت کنید، شاخه اصلی آن مخزن را در شاخه موضوعی خود ادغام کنید، مشکلات را برطرف کنید و در نهایت آن را به همان شاخه‌ای که درخواست ادغام را باز کرده‌اید پوش کنید.
+
+برای مثال فرض کنید در مثال "`tonychacon`"، نویسنده اصلی تغییراتی داده که باعث ایجاد تعارض در درخواست ادغام می‌شود. مراحل زیر را طی می‌کنیم:
 
 [source,console]
 ----
@@ -276,87 +268,84 @@ To https://github.com/tonychacon/blink
    ef4725c..3c8d735  slower-blink -> slow-blink
 ----
 
-<1> Add the original repository as a remote named `upstream`.
-<2> Fetch the newest work from that remote.
-<3> Merge the main branch of that repository into your topic branch.
-<4> Fix the conflict that occurred.
-<5> Push back up to the same topic branch.
+<1> مخزن اصلی را به عنوان ریموتی به نام `upstream` اضافه کنید.
+<2> جدیدترین تغییرات را از آن ریموت دریافت کنید.
+<3> شاخه اصلی آن مخزن را در شاخه موضوعی خود ادغام کنید.
+<4> تعارض پیش آمده را برطرف کنید.
+<5> تغییرات را به همان شاخه موضوعی پوش کنید.
 
-Once you do that, the Pull Request will be automatically updated and re-checked to see if it merges cleanly.
+وقتی این کار را انجام دهید، درخواست ادغام به طور خودکار به‌روزرسانی شده و دوباره بررسی می‌شود تا ببیند آیا به‌طور تمیز ادغام می‌شود یا خیر.
 
 [[_pr_merge_fix]]
 .Pull Request now merges cleanly
 image::images/pr-02-merge-fix.png[Pull Request now merges cleanly]
 
-One of the great things about Git is that you can do that continuously.
-If you have a very long-running project, you can easily merge from the target branch over and over again and only have to deal with conflicts that have arisen since the last time that you merged, making the process very manageable.
+یکی از مزایای بزرگ گیت این است که می‌توانید این کار را به صورت مداوم انجام دهید. اگر پروژه‌ای طولانی‌مدت دارید، می‌توانید بارها و بارها از شاخه هدف ادغام بگیرید و تنها با تعارض‌هایی که از آخرین ادغام به وجود آمده‌اند مواجه شوید که این روند را بسیار قابل مدیریت می‌کند.
 
-If you absolutely wish to rebase the branch to clean it up, you can certainly do so, but it is highly encouraged to not force push over the branch that the Pull Request is already opened on.
-If other people have pulled it down and done more work on it, you run into all of the issues outlined in <<ch03-git-branching#_rebase_peril>>.
-Instead, push the rebased branch to a new branch on GitHub and open a brand new Pull Request referencing the old one, then close the original.
+اگر واقعاً می‌خواهید شاخه را ری‌بیس کنید تا آن را تمیز کنید، قطعاً می‌توانید این کار را انجام دهید، اما اکیداً توصیه می‌شود که روی شاخه‌ای که درخواست ادغام روی آن باز است، پوش فورس انجام ندهید. اگر افراد دیگری آن را دریافت و روی آن کار کرده باشند، با مشکلات بسیار زیادی مواجه خواهید شد که در <<ch03-git-branching#_rebase_peril>> توضیح داده شده است. در عوض، شاخه ری‌بیس شده را به شاخه جدیدی در گیت‌هاب پوش کنید و درخواست ادغام جدیدی باز کنید که به درخواست قبلی ارجاع دهد، سپس درخواست اصلی را ببندید.
 
-===== References
+===== References (ارجاع‌ها)
 
-Your next question may be "`How do I reference the old Pull Request?`".
-It turns out there are many, many ways to reference other things almost anywhere you can write in GitHub.
+شاید سؤال بعدی شما این باشد: «چگونه به درخواست ادغام قدیمی ارجاع دهم؟»
+واقعیت این است که راه‌های بسیار زیادی برای ارجاع به چیزهای دیگر تقریباً در هر جایی که در گیت‌هاب می‌توانید بنویسید وجود دارد.
 
-Let's start with how to cross-reference another Pull Request or an Issue.
-All Pull Requests and Issues are assigned numbers and they are unique within the project.
-For example, you can't have Pull Request +#3+ _and_ Issue +#3+.
-If you want to reference any Pull Request or Issue from any other one, you can simply put `+#<num>+` in any comment or description.
-You can also be more specific if the Issue or Pull request lives somewhere else; write `username#<num>` if you're referring to an Issue or Pull Request in a fork of the repository you're in, or `username/repo#<num>` to reference something in another repository.
+بیایید با نحوه ارجاع به درخواست ادغام یا مسئله‌ی دیگر شروع کنیم.
+تمام درخواست‌های ادغام و مسائل شماره‌گذاری شده و این شماره‌ها در پروژه یکتا هستند.
+برای مثال، نمی‌توانید درخواست ادغام شماره ۳ و مسئله شماره ۳ داشته باشید که هر دو در یک پروژه باشند.
+اگر بخواهید به هر درخواست ادغام یا مسئله‌ای از هر درخواست یا مسئله‌ی دیگر ارجاع دهید، کافی است `#<شماره>` را در هر کامنت یا توضیحی بنویسید.
+همچنین می‌توانید دقیق‌تر باشید اگر مسئله یا درخواست ادغام در جای دیگری است؛ برای ارجاع به مسئله یا درخواست ادغام در فورکی از مخزنی که در آن هستید، `username#<شماره>` را بنویسید، یا برای ارجاع به چیزی در مخزن دیگر، `username/repo#<شماره>` را استفاده کنید.
 
-Let's look at an example.
-Say we rebased the branch in the previous example, created a new pull request for it, and now we want to reference the old pull request from the new one.
-We also want to reference an issue in the fork of the repository and an issue in a completely different project.
-We can fill out the description just like <<_pr_references>>.
+ بیایید یک مثال را بررسی کنیم.
+فرض کنید در مثال قبلی، شاخه را بازبیس (rebase) کرده‌ایم، یک درخواست کشش (pull request) جدید برای آن ساخته‌ایم و حالا می‌خواهیم از درخواست کشش قدیمی در درخواست جدید ارجاع دهیم.
+همچنین می‌خواهیم به یک مسئله (issue) در فورک مخزن و یک مسئله در پروژه‌ای کاملاً متفاوت اشاره کنیم.
+می‌توانیم توضیحات را دقیقاً مانند <<_pr_references>> پر کنیم.
 
 [[_pr_references]]
 .Cross references in a Pull Request
 image::images/mentions-01-syntax.png[Cross references in a Pull Request]
 
-When we submit this pull request, we'll see all of that rendered like <<_pr_references_render>>.
+وقتی این درخواست کشش را ارسال کنیم، همه این موارد به شکل <<_pr_references_render>> نمایش داده می‌شوند.
 
 [[_pr_references_render]]
 .Cross references rendered in a Pull Request
 image::images/mentions-02-render.png[Cross references rendered in a Pull Request]
 
-Notice that the full GitHub URL we put in there was shortened to just the information needed.
+توجه کنید که URL کامل گیت‌هاب که وارد کرده‌ایم، به اطلاعات مورد نیاز خلاصه شده است.
 
-Now if Tony goes back and closes out the original Pull Request, we can see that by mentioning it in the new one, GitHub has automatically created a trackback event in the Pull Request timeline.
-This means that anyone who visits this Pull Request and sees that it is closed can easily link back to the one that superseded it.
-The link will look something like <<_pr_closed>>.
+حالا اگر تونی برگردد و درخواست کشش اصلی را ببندد، می‌بینیم که با اشاره به آن در درخواست جدید، گیت‌هاب به صورت خودکار یک رویداد پیگیری (trackback) در جدول زمانی درخواست کشش ایجاد کرده است.
+این بدان معناست که هر کسی که این درخواست کشش را مشاهده کند و ببیند که بسته شده، به راحتی می‌تواند به آن درخواست کشش که این را جایگزین کرده، لینک بزند.
+این لینک چیزی شبیه به <<_pr_closed>> خواهد بود.
 
 [[_pr_closed]]
 .Link back to the new Pull Request in the closed Pull Request timeline
 image::images/mentions-03-closed.png[Link back to the new Pull Request in the closed Pull Request timeline]
 
-In addition to issue numbers, you can also reference a specific commit by SHA-1.
-You have to specify a full 40 character SHA-1, but if GitHub sees that in a comment, it will link directly to the commit.
-Again, you can reference commits in forks or other repositories in the same way you did with issues.
+علاوه بر شماره مسائل، می‌توانید به یک کامیت خاص با شناسه SHA-1 هم ارجاع دهید.
+باید یک SHA-1 کامل ۴۰ حرفی مشخص کنید، اما اگر گیت‌هاب آن را در یک کامنت ببیند، مستقیماً به کامیت لینک می‌دهد.
+دوباره، می‌توانید به کامیت‌ها در فورک‌ها یا مخازن دیگر به همان روشی که به مسائل اشاره می‌کنید، ارجاع دهید.
 
-==== GitHub Flavored Markdown
+==== GitHub Flavored Markdown (مارک‌داون با طعم گیت‌هاب)
 
-Linking to other Issues is just the beginning of interesting things you can do with almost any text box on GitHub.
-In Issue and Pull Request descriptions, comments, code comments and more, you can use what is called "`GitHub Flavored Markdown`".
-Markdown is like writing in plain text but which is rendered richly.
+لینک دادن به مسائل دیگر تنها آغاز کارهای جالبی است که می‌توانید در تقریباً هر کادر متنی در گیت‌هاب انجام دهید.
+در توضیحات مسائل و درخواست‌های کشش، کامنت‌ها، کامنت‌های کد و موارد دیگر، می‌توانید از چیزی به نام «مارک‌داون با طعم گیت‌هاب» استفاده کنید.
+مارک‌داون شبیه نوشتن متن ساده است اما به صورت غنی نمایش داده می‌شود.
 
-See <<_example_markdown>> for an example of how comments or text can be written and then rendered using Markdown.
+برای نمونه‌ای از نحوه نوشتن و نمایش کامنت‌ها یا متن با استفاده از مارک‌داون، به <<_example_markdown>> مراجعه کنید.
 
 [[_example_markdown]]
 .An example of GitHub Flavored Markdown as written and as rendered
 image::images/markdown-01-example.png[An example of GitHub Flavored Markdown as written and as rendered]
 
-The GitHub flavor of Markdown adds more things you can do beyond the basic Markdown syntax.
-These can all be really useful when creating useful Pull Request or Issue comments or descriptions.
+طعم گیت‌هاب از مارک‌داون امکانات بیشتری فراتر از نحو پایه مارک‌داون اضافه می‌کند.
+این امکانات هنگام نوشتن کامنت‌ها یا توضیحات مفید برای درخواست‌های کشش یا مسائل بسیار کاربردی هستند.
 
-===== Task Lists
+===== Task Lists (فهرست وظایف)
 
-The first really useful GitHub specific Markdown feature, especially for use in Pull Requests, is the Task List.
-A task list is a list of checkboxes of things you want to get done.
-Putting them into an Issue or Pull Request normally indicates things that you want to get done before you consider the item complete.
+اولین ویژگی واقعاً کاربردی مارک‌داون مخصوص گیت‌هاب، به ویژه برای استفاده در درخواست‌های کشش، فهرست وظایف است.
+فهرست وظایف، فهرستی از جعبه‌های انتخاب (checkbox) است که کارهایی را که می‌خواهید انجام دهید نشان می‌دهد.
+قرار دادن آن‌ها در یک مسئله یا درخواست کشش معمولاً به این معناست که این کارها باید انجام شوند تا آن موضوع کامل در نظر گرفته شود.
 
-You can create a task list like this:
+می‌توانید فهرست وظایف را این‌گونه بسازید:
 
 [source,text]
 ----
@@ -365,33 +354,33 @@ You can create a task list like this:
 - [ ] Document the code
 ----
 
-If we include this in the description of our Pull Request or Issue, we'll see it rendered like <<_eg_task_lists>>.
+اگر این را در توضیحات درخواست کشش یا مسئله بگنجانید، به شکل <<_eg_task_lists>> نمایش داده می‌شود.
 
 [[_eg_task_lists]]
 .Task lists rendered in a Markdown comment
 image::images/markdown-02-tasks.png[Task lists rendered in a Markdown comment]
 
-This is often used in Pull Requests to indicate what all you would like to get done on the branch before the Pull Request will be ready to merge.
-The really cool part is that you can simply click the checkboxes to update the comment -- you don't have to edit the Markdown directly to check tasks off.
+این اغلب در درخواست‌های کشش استفاده می‌شود تا نشان دهد چه کارهایی باید روی شاخه انجام شود تا درخواست کشش آماده ادغام شود.
+قسمت جالب این است که می‌توانید صرفاً با کلیک روی جعبه‌های انتخاب، کامنت را به‌روزرسانی کنید — نیازی نیست خود مارک‌داون را مستقیماً ویرایش کنید تا وظایف را تیک بزنید.
 
-What's more, GitHub will look for task lists in your Issues and Pull Requests and show them as metadata on the pages that list them out.
-For example, if you have a Pull Request with tasks and you look at the overview page of all Pull Requests, you can see how far done it is.
-This helps people break down Pull Requests into subtasks and helps other people track the progress of the branch.
-You can see an example of this in <<_task_list_progress>>.
+علاوه بر این، گیت‌هاب در مسائل و درخواست‌های کشش به دنبال فهرست‌های وظایف می‌گردد و آن‌ها را به صورت فراداده (metadata) در صفحاتی که لیست می‌کنند نمایش می‌دهد.
+برای مثال، اگر یک درخواست کشش با وظایف داشته باشید و صفحه نمای کلی تمام درخواست‌های کشش را ببینید، می‌توانید میزان پیشرفت آن را مشاهده کنید.
+این به افراد کمک می‌کند درخواست‌های کشش را به وظایف خردتر تقسیم کنند و دیگران را در جریان پیشرفت شاخه قرار دهد.
+می‌توانید نمونه‌ای از این را در <<_task_list_progress>> ببینید.
 
 [[_task_list_progress]]
 .Task list summary in the Pull Request list
 image::images/markdown-03-task-summary.png[Task list summary in the Pull Request list]
 
-These are incredibly useful when you open a Pull Request early and use it to track your progress through the implementation of the feature.
+این‌ها زمانی که درخواست کشش را زود باز می‌کنید و از آن برای پیگیری پیشرفت پیاده‌سازی ویژگی استفاده می‌کنید، فوق‌العاده کاربردی هستند.
 
-===== Code Snippets
+===== Code Snippets (قطعه‌های کد)
 
-You can also add code snippets to comments.
-This is especially useful if you want to present something that you _could_ try to do before actually implementing it as a commit on your branch.
-This is also often used to add example code of what is not working or what this Pull Request could implement.
+همچنین می‌توانید قطعه‌های کد را به کامنت‌ها اضافه کنید.
+این وقتی مفید است که بخواهید چیزی را نشان دهید که ممکن است قبل از پیاده‌سازی آن به عنوان یک کامیت روی شاخه، امتحانش کنید.
+اغلب برای افزودن کد نمونه‌ای از چیزی که کار نمی‌کند یا چیزی که این درخواست کشش می‌تواند پیاده‌سازی کند، استفاده می‌شود.
 
-To add a snippet of code you have to "`fence`" it in backticks.
+برای افزودن قطعه کد باید آن را در بک‌تیک (backticks) «محصور» کنید.
 
 [source,text]
 ----
@@ -403,20 +392,20 @@ for(int i=0 ; i < 5 ; i++)
 ```
 ----
 
-If you add a language name like we did there with 'java', GitHub will also try to syntax highlight the snippet.
-In the case of the above example, it would end up rendering like <<_md_code>>.
+ اگر نام یک زبان برنامه‌نویسی مثل «java» را اضافه کنید، همان‌طور که در مثال بالا انجام دادیم، گیت‌هاب نیز سعی می‌کند کد را با برجسته‌سازی نحوی نمایش دهد.
+در مورد مثال بالا، خروجی به صورت <<_md_code>> خواهد بود.
 
 [[_md_code]]
 .Rendered fenced code example
 image::images/markdown-04-fenced-code.png[Rendered fenced code example]
 
-===== Quoting
+===== Quoting (نقل قول)
 
-If you're responding to a small part of a long comment, you can selectively quote out of the other comment by preceding the lines with the `>` character.
-In fact, this is so common and so useful that there is a keyboard shortcut for it.
-If you highlight text in a comment that you want to directly reply to and hit the `r` key, it will quote that text in the comment box for you.
+اگر می‌خواهید به بخش کوچکی از یک نظر طولانی پاسخ دهید، می‌توانید به‌صورت انتخابی بخشی از آن نظر را با گذاشتن علامت `>` در ابتدای خطوط نقل قول کنید.
+در واقع، این کار به قدری رایج و مفید است که یک میانبر صفحه‌کلید برای آن وجود دارد.
+اگر متنی را در یک نظر هایلایت کرده و کلید `r` را فشار دهید، آن متن به‌صورت نقل قول در جعبه نظر برای شما درج می‌شود.
 
-The quotes look something like this:
+نقل قول‌ها چیزی شبیه به این هستند:
 
 [source,text]
 ----
@@ -426,25 +415,25 @@ The quotes look something like this:
 How big are these slings and in particular, these arrows?
 ----
 
-Once rendered, the comment will look like <<_md_quote>>.
+وقتی نمایش داده شوند، نظر به صورت <<_md_quote>> دیده خواهد شد.
 
 [[_md_quote]]
 .Rendered quoting example
 image::images/markdown-05-quote.png[Rendered quoting example]
 
-===== Emoji
+===== Emoji (ایموجی)
 
-Finally, you can also use emoji in your comments.
-This is actually used quite extensively in comments you see on many GitHub Issues and Pull Requests.
-There is even an emoji helper in GitHub.
-If you are typing a comment and you start with a `:` character, an autocompleter will help you find what you're looking for.
+در نهایت، شما می‌توانید در نظرات خود از ایموجی هم استفاده کنید.
+این کار در نظرات بسیاری از مسائل و درخواست‌های pull در گیت‌هاب به‌طور گسترده‌ای به کار می‌رود.
+حتی یک راهنمای ایموجی در گیت‌هاب وجود دارد.
+اگر در حال نوشتن نظر باشید و با کاراکتر `:` شروع کنید، یک تکمیل‌کننده خودکار به شما کمک می‌کند ایموجی مورد نظر خود را پیدا کنید.
 
 [[_md_emoji_auto]]
 .Emoji autocompleter in action
 image::images/markdown-06-emoji-complete.png[Emoji autocompleter in action]
 
-Emojis take the form of `:<name>:` anywhere in the comment.
-For instance, you could write something like this:
+ایموجی‌ها به شکل `:<name>:` در هر جای نظر قابل استفاده هستند.
+برای مثال، می‌توانید چیزی شبیه به این بنویسید:
 
 [source,text]
 ----
@@ -457,50 +446,50 @@ I :eyes: that :bug: and I :cold_sweat:.
 :clap::tada::panda_face:
 ----
 
-When rendered, it would look something like <<_md_emoji>>.
+زمانی که نمایش داده شود، چیزی شبیه <<_md_emoji>> خواهد بود.
 
 [[_md_emoji]]
 .Heavy emoji commenting
 image::images/markdown-07-emoji.png[Heavy emoji commenting]
 
-Not that this is incredibly useful, but it does add an element of fun and emotion to a medium that is otherwise hard to convey emotion in.
+ممکن است این ابزار خیلی ضروری به نظر نرسد، اما به محیطی که انتقال احساس در آن سخت است، عنصر سرگرمی و احساس اضافه می‌کند.
 
 [NOTE]
 ====
-There are actually quite a number of web services that make use of emoji characters these days.
-A great cheat sheet to reference to find emoji that expresses what you want to say can be found at:
+امروزه سرویس‌های وب زیادی از کاراکترهای ایموجی استفاده می‌کنند.
+یک راهنمای کامل و مفید برای پیدا کردن ایموجی‌های مناسب، در لینک زیر موجود است:
 
 https://www.webfx.com/tools/emoji-cheat-sheet/[^]
 ====
 
-===== Images
+===== Images (تصاویر)
 
-This isn't technically GitHub Flavored Markdown, but it is incredibly useful.
-In addition to adding Markdown image links to comments, which can be difficult to find and embed URLs for, GitHub allows you to drag and drop images into text areas to embed them.
+این تکنیک به‌طور فنی بخشی از Markdown مخصوص گیت‌هاب نیست، اما بسیار کاربردی است.
+علاوه بر افزودن لینک‌های تصویر Markdown به نظرات که یافتن و جایگذاری آدرس‌های URL آنها ممکن است دشوار باشد، گیت‌هاب امکان کشیدن و رها کردن تصاویر در ناحیه متن برای افزودن آنها را فراهم می‌کند.
 
 [[_md_drag]]
 .Drag and drop images to upload them and auto-embed them
 image::images/markdown-08-drag-drop.png[Drag and drop images to upload them and auto-embed them]
 
-If you look at <<_md_drag>>, you can see a small "`Parsed as Markdown`" hint above the text area.
-Clicking on that will give you a full cheat sheet of everything you can do with Markdown on GitHub.
+اگر به <<_md_drag>> نگاه کنید، می‌توانید یک راهنمای کوچک با عنوان «Parsed as Markdown» را بالای ناحیه متن ببینید.
+کلیک روی آن، یک راهنمای کامل از همه قابلیت‌های Markdown روی گیت‌هاب را به شما نشان می‌دهد.
 
 [[_fetch_and_push_on_different_repositories]]
-==== Keep your GitHub public repository up-to-date
+==== Keep your GitHub public repository up-to-date (به‌روزرسانی مخزن عمومی گیت‌هاب خود را حفظ کنید)
 
-Once you've forked a GitHub repository, your repository (your "fork") exists independently from the original.
-In particular, when the original repository has new commits, GitHub informs you by a message like:
+پس از فورک کردن یک مخزن گیت‌هاب، مخزن شما (یا همان «فورک» شما) به‌صورت مستقل از مخزن اصلی وجود خواهد داشت.
+به‌خصوص وقتی مخزن اصلی کامیت‌های جدیدی دارد، گیت‌هاب با پیامی مانند زیر به شما اطلاع می‌دهد:
 
 [source,text]
 ----
 This branch is 5 commits behind progit:master.
 ----
 
-But your GitHub repository will never be automatically updated by GitHub; this is something that you must do yourself.
-Fortunately, this is very easy to do.
+اما مخزن گیت‌هاب شما هرگز به‌طور خودکار توسط گیت‌هاب به‌روزرسانی نمی‌شود؛ این کاری است که باید خودتان انجام دهید.
+خوشبختانه، این کار بسیار آسان است.
 
-One possibility to do this requires no configuration.
-For example, if you forked from `https://github.com/progit/progit2.git`, you can keep your `master` branch up-to-date like this:
+یکی از روش‌های انجام این کار بدون نیاز به تنظیمات خاص این است که:
+برای مثال، اگر شما از `https://github.com/progit/progit2.git` فورک گرفته‌اید، می‌توانید شاخه‌ی `master` خود را به این شکل به‌روز نگه دارید:
 
 [source,console]
 ----
@@ -509,12 +498,12 @@ $ git pull https://github.com/progit/progit2.git <2>
 $ git push origin master <3>
 ----
 
-<1> If you were on another branch, return to `master`.
-<2> Fetch changes from `https://github.com/progit/progit2.git` and merge them into `master`.
-<3> Push your `master` branch to `origin`.
+<1> اگر روی شاخه‌ای دیگر بودید، به شاخهٔ `master` بازگردید.
+<2> تغییرات را از `https://github.com/progit/progit2.git` دریافت کرده و با شاخهٔ `master` ادغام کنید.
+<3> شاخهٔ `master` خود را به مخزن `origin` ارسال کنید.
 
-This works, but it is a little tedious having to spell out the fetch URL every time.
-You can automate this work with a bit of configuration:
+این روش کار می‌کند، اما هر بار باید آدرس URL دریافت را به صورت کامل وارد کنید که کمی خسته‌کننده است.
+می‌توانید با کمی تنظیمات این کار را خودکار کنید
 
 [source,console]
 ----
@@ -524,13 +513,13 @@ $ git branch --set-upstream-to=progit/master master <3>
 $ git config --local remote.pushDefault origin <4>
 ----
 
-<1> Add the source repository and give it a name.
-    Here, I have chosen to call it `progit`.
-<2> Get a reference on progit's branches, in particular `master`.
-<3> Set your `master` branch to fetch from the `progit` remote.
-<4> Define the default push repository to `origin`.
+<1> مخزن منبع را اضافه کرده و نامی برای آن انتخاب کنید.
+    در اینجا من نام `progit` را انتخاب کرده‌ام.
+<2> مرجع شاخه‌های progit، به ویژه `master` را دریافت کنید.
+<3> شاخهٔ `master` خود را طوری تنظیم کنید که از مخزن راه دور `progit` دریافت کند.
+<4> مخزن پیش‌فرض برای ارسال تغییرات را روی `origin` تعریف کنید.
 
-Once this is done, the workflow becomes much simpler:
+پس از انجام این تنظیمات، روند کار بسیار ساده‌تر می‌شود:
 
 [source,console]
 ----
@@ -539,10 +528,10 @@ $ git pull <2>
 $ git push <3>
 ----
 
-<1> If you were on another branch, return to `master`.
-<2> Fetch changes from `progit` and merge changes into `master`.
-<3> Push your `master` branch to `origin`.
+<1> اگر روی شاخه‌ای دیگر بودید، به شاخهٔ `master` بازگردید.
+<2> تغییرات را از `progit` دریافت کرده و با شاخهٔ `master` ادغام کنید.
+<3> شاخهٔ `master` خود را به مخزن `origin` ارسال کنید.
 
-This approach can be useful, but it's not without downsides.
-Git will happily do this work for you silently, but it won't warn you if you make a commit to `master`, pull from `progit`, then push to `origin` -- all of those operations are valid with this setup.
-So you'll have to take care never to commit directly to `master`, since that branch effectively belongs to the upstream repository.
+این روش ممکن است مفید باشد، اما بدون معایب نیست.
+گیت با خوشحالی این کار را به صورت پنهان برای شما انجام می‌دهد، اما اگر شما مستقیماً روی `master` کامیت بزنید، سپس از `progit` دریافت کنید و بعد به `origin` ارسال کنید، هشدار نخواهد داد — همهٔ این عملیات‌ها با این تنظیمات معتبر هستند.
+بنابراین باید مراقب باشید که هرگز مستقیماً روی `master` کامیت نزنید، چون این شاخه عملاً متعلق به مخزن بالادستی است.

--- a/book/06-github/sections/3-maintaining.asc
+++ b/book/06-github/sections/3-maintaining.asc
@@ -1,12 +1,12 @@
 [[_maintaining_gh_project]]
-=== Maintaining a Project
+=== Maintaining a Project (نگهداری یک پروژه)
 
-Now that we're comfortable contributing to a project, let's look at the other side: creating, maintaining and administering your own project.
+حالا که در مشارکت در یک پروژه راحت شده‌ایم، بیایید به سمت دیگر قضیه نگاه کنیم: ایجاد، نگهداری و مدیریت پروژه‌ی خودتان.
 
-==== Creating a New Repository
+==== Creating a New Repository (ایجاد یک مخزن جدید)
 
-Let's create a new repository to share our project code with.
-Start by clicking the "`New repository`" button on the right-hand side of the dashboard, or from the `+` button in the top toolbar next to your username as seen in <<_new_repo_dropdown>>.
+بیایید یک مخزن جدید بسازیم تا کد پروژه‌مان را به اشتراک بگذاریم.
+با کلیک روی دکمه‌ی «New repository» در سمت راست داشبورد شروع کنید، یا از دکمه‌ی «+» در نوار ابزار بالای صفحه کنار نام کاربری‌تان استفاده کنید، همانطور که در <<_new_repo_dropdown>> دیده می‌شود.
 
 .The "`Your repositories`" area
 image::images/newrepo.png[The “Your repositories” area]
@@ -15,120 +15,117 @@ image::images/newrepo.png[The “Your repositories” area]
 .The "`New repository`" dropdown
 image::images/new-repo.png[The “New repository” dropdown]
 
-This takes you to the "`new repository`" form:
+این شما را به فرم "`new repository`" هدایت می‌کند:
 
 .The "`new repository`" form
 image::images/newrepoform.png[The “new repository” form]
 
-All you really have to do here is provide a project name; the rest of the fields are completely optional.
-For now, just click the "`Create Repository`" button, and boom -- you have a new repository on GitHub, named `<user>/<project_name>`.
+تنها کاری که واقعاً باید انجام دهید این است که نام پروژه را وارد کنید؛ بقیه فیلدها کاملاً اختیاری هستند.
+فعلاً فقط روی دکمه‌ی «Create Repository» کلیک کنید، و همین‌طور — یک مخزن جدید روی گیت‌هاب با نام `<user>/<project_name>` دارید.
 
-Since you have no code there yet, GitHub will show you instructions for how to create a brand-new Git repository, or connect an existing Git project.
-We won't belabor this here; if you need a refresher, check out <<ch02-git-basics-chapter#ch02-git-basics-chapter>>.
+از آنجا که هنوز هیچ کدی در این مخزن نیست، گیت‌هاب به شما دستورالعمل‌هایی برای ساخت یک مخزن گیت کاملاً جدید یا اتصال یک پروژه‌ی گیت موجود نشان می‌دهد.
+ما اینجا وارد جزئیات نمی‌شویم؛ اگر نیاز به بازخوانی دارید، بخش <<ch02-git-basics-chapter#ch02-git-basics-chapter>> را مطالعه کنید.
 
-Now that your project is hosted on GitHub, you can give the URL to anyone you want to share your project with.
-Every project on GitHub is accessible over HTTPS as `\https://github.com/<user>/<project_name>`, and over SSH as `\git@github.com:<user>/<project_name>`.
-Git can fetch from and push to both of these URLs, but they are access-controlled based on the credentials of the user connecting to them.
+حالا که پروژه‌ی شما روی گیت‌هاب میزبانی شده است، می‌توانید آدرس URL آن را به هر کسی که می‌خواهید پروژه را با او به اشتراک بگذارید، بدهید.
+هر پروژه‌ای روی گیت‌هاب از طریق HTTPS به صورت `https://github.com/<user>/<project_name>` و از طریق SSH به صورت `git@github.com:<user>/<project_name>` قابل دسترسی است.
+گیت می‌تواند از هر دو URL دریافت و ارسال کند، اما دسترسی به آن‌ها بر اساس اعتبارنامه‌های کاربری که به آن‌ها متصل می‌شوند کنترل می‌شود.
 
 [NOTE]
 ====
-It is often preferable to share the HTTPS based URL for a public project, since the user does not have to have a GitHub account to access it for cloning.
-Users will have to have an account and an uploaded SSH key to access your project if you give them the SSH URL.
-The HTTPS one is also exactly the same URL they would paste into a browser to view the project there.
+اغلب ترجیح داده می‌شود که URL مبتنی بر HTTPS را برای پروژه‌های عمومی به اشتراک بگذارید، چرا که کاربر برای کلون کردن نیازی به حساب کاربری گیت‌هاب ندارد.
+اگر URL SSH را بدهید، کاربران باید حساب کاربری و کلید SSH آپلود شده داشته باشند تا بتوانند به پروژه دسترسی پیدا کنند.
+همچنین، URL HTTPS همان آدرسی است که آن‌ها می‌توانند در مرورگر خود برای مشاهده پروژه وارد کنند.
 ====
 
-==== Adding Collaborators
+==== Adding Collaborators (اضافه کردن همکاران)
 
-If you're working with other people who you want to give commit access to, you need to add them as "`collaborators`".
-If Ben, Jeff, and Louise all sign up for accounts on GitHub, and you want to give them push access to your repository, you can add them to your project.
-Doing so will give them "`push`" access, which means they have both read and write access to the project and Git repository.
+اگر با افرادی کار می‌کنید که می‌خواهید دسترسی تعهد (commit) به آن‌ها بدهید، باید آن‌ها را به عنوان «collaborators» اضافه کنید.
+اگر بن، جف و لوئیس همه در گیت‌هاب حساب کاربری بسازند و شما بخواهید دسترسی push به مخزن خود بدهید، می‌توانید آن‌ها را به پروژه اضافه کنید.
+این کار به آن‌ها دسترسی «push» می‌دهد، بدین معنا که هم به پروژه و مخزن گیت خواندن و نوشتن دارند.
 
-Click the "`Settings`" link at the bottom of the right-hand sidebar.
+روی لینک "`Setting`" در پایین نوار کناری سمت راست کلیک کنید.
 
 .The repository settings link
 image::images/reposettingslink.png[The repository settings link]
 
-Then select "`Collaborators`" from the menu on the left-hand side.
-Then, just type a username into the box, and click "`Add collaborator.`"
-You can repeat this as many times as you like to grant access to everyone you like.
-If you need to revoke access, just click the "`X`" on the right-hand side of their row.
+سپس از منوی سمت چپ «Collaborators» را انتخاب کنید.
+بعد، فقط نام کاربری را در کادر تایپ کنید و روی «Add collaborator» کلیک کنید.
+می‌توانید این کار را به هر تعداد که دوست دارید تکرار کنید تا به همه‌ی افراد دلخواه دسترسی بدهید.
+اگر نیاز به لغو دسترسی داشتید، فقط روی «X» در سمت راست ردیف آن‌ها کلیک کنید.
 
 .The repository collaborators box
 image::images/collaborators.png[The repository collaborators box]
 
-==== Managing Pull Requests
+==== Managing Pull Requests (مدیریت درخواست‌های Pull)
 
-Now that you have a project with some code in it and maybe even a few collaborators who also have push access, let's go over what to do when you get a Pull Request yourself.
+حالا که یک پروژه با مقداری کد دارید و شاید چند همکار که دسترسی push دارند، بیایید ببینیم وقتی خودتان یک Pull Request دریافت می‌کنید، چه کار باید بکنید.
 
-Pull Requests can either come from a branch in a fork of your repository or they can come from another branch in the same repository.
-The only difference is that the ones in a fork are often from people where you can't push to their branch and they can't push to yours, whereas with internal Pull Requests generally both parties can access the branch.
+درخواست‌های Pull می‌توانند یا از یک شاخه در یک فورک مخزن شما بیایند یا از شاخه‌ای دیگر در همان مخزن.
+تنها تفاوت این است که درخواست‌های Pull در فورک‌ها اغلب از افرادی هستند که شما نمی‌توانید به شاخه آن‌ها push کنید و آن‌ها هم نمی‌توانند به شاخه شما push کنند، در حالی که در درخواست‌های Pull داخلی معمولاً هر دو طرف به شاخه دسترسی دارند.
 
-For these examples, let's assume you are "`tonychacon`" and you've created a new Arduino code project named "`fade`".
+برای این مثال‌ها فرض کنیم شما "`tonychacon`" هستید و یک پروژه کد آردوینو به نام «fade» ساخته‌اید.
 
 [[_email_notifications]]
-===== Email Notifications
+===== Email Notifications (اعلان‌های ایمیلی)
 
-Someone comes along and makes a change to your code and sends you a Pull Request.
-You should get an email notifying you about the new Pull Request and it should look something like <<_email_pr>>.
+کسی می‌آید و تغییری در کد شما ایجاد می‌کند و یک Pull Request برای شما ارسال می‌کند.
+شما باید ایمیلی دریافت کنید که در مورد Pull Request جدید اطلاع دهد و این ایمیل باید چیزی شبیه به <<_email_pr>> باشد.
 
 [[_email_pr]]
 .Email notification of a new Pull Request
 image::images/maint-01-email.png[Email notification of a new Pull Request]
 
-There are a few things to notice about this email.
-It will give you a small diffstat -- a list of files that have changed in the Pull Request and by how much.
-It gives you a link to the Pull Request on GitHub.
-It also gives you a few URLs that you can use from the command line.
+ چند نکته درباره این ایمیل وجود دارد که باید بدانید.
+این ایمیل یک خلاصه کوچک از تغییرات (diffstat) به شما می‌دهد — فهرستی از فایل‌هایی که در درخواست Pull تغییر کرده‌اند و میزان تغییرات آن‌ها.
+همچنین یک لینک به درخواست Pull در گیت‌هاب به شما ارائه می‌کند.
+چند URL نیز دارد که می‌توانید از طریق خط فرمان از آن‌ها استفاده کنید.
 
-If you notice the line that says `git pull <url> patch-1`, this is a simple way to merge in a remote branch without having to add a remote.
-We went over this quickly in <<ch05-distributed-git#_checking_out_remotes>>.
-If you wish, you can create and switch to a topic branch and then run this command to merge in the Pull Request changes.
+اگر به خطی که نوشته `git pull <url> patch-1` دقت کنید، این یک روش ساده برای ادغام یک شاخه از راه دور بدون نیاز به اضافه کردن remote است.
+ما این موضوع را سریعاً در <<ch05-distributed-git#_checking_out_remotes>> مرور کردیم.
+اگر بخواهید، می‌توانید یک شاخه موضوعی (topic branch) ایجاد و به آن سوئیچ کنید و سپس این دستور را اجرا کنید تا تغییرات درخواست Pull را ادغام کنید.
 
-The other interesting URLs are the `.diff` and `.patch` URLs, which as you may guess, provide unified diff and patch versions of the Pull Request.
-You could technically merge in the Pull Request work with something like this:
+URLهای جالب دیگر، URLهای `.diff` و `.patch` هستند که همان‌طور که حدس می‌زنید، نسخه‌های unified diff و patch از درخواست Pull را ارائه می‌دهند.
+از نظر فنی، می‌توانید کار درخواست Pull را با چیزی شبیه به این ادغام کنید:
 
 [source,console]
 ----
 $ curl https://github.com/tonychacon/fade/pull/1.patch | git am
 ----
 
-===== Collaborating on the Pull Request
+===== Collaborating on the Pull Request (همکاری روی درخواست Pull  )
 
-As we covered in <<ch06-github#ch06-github_flow>>, you can now have a conversation with the person who opened the Pull Request.
-You can comment on specific lines of code, comment on whole commits or comment on the entire Pull Request itself, using GitHub Flavored Markdown everywhere.
+همان‌طور که در <<ch06-github#ch06-github_flow>> توضیح دادیم، اکنون می‌توانید با شخصی که درخواست Pull را باز کرده است گفتگو کنید.
+می‌توانید روی خطوط خاصی از کد نظر بگذارید، روی کامیت‌های کامل یا کل درخواست Pull نظر بدهید و در همه جا از Markdown با سبک GitHub استفاده کنید.
 
-Every time someone else comments on the Pull Request you will continue to get email notifications so you know there is activity happening.
-They will each have a link to the Pull Request where the activity is happening and you can also directly respond to the email to comment on the Pull Request thread.
+هر بار که شخص دیگری روی درخواست Pull نظر می‌دهد، شما ایمیل اطلاع‌رسانی دریافت می‌کنید تا بدانید فعالیتی در حال انجام است.
+هر ایمیل شامل لینکی به درخواست Pull است که فعالیت در آنجا اتفاق می‌افتد و همچنین می‌توانید مستقیماً به ایمیل پاسخ دهید و در همان رشته (thread) درخواست Pull نظر بگذارید.
 
 .Responses to emails are included in the thread
 image::images/maint-03-email-resp.png[Responses to emails are included in the thread]
 
-Once the code is in a place you like and want to merge it in, you can either pull the code down and merge it locally, either with the `git pull <url> <branch>` syntax we saw earlier, or by adding the fork as a remote and fetching and merging.
+وقتی کد به جایی رسید که راضی بودید و می‌خواهید آن را ادغام کنید، می‌توانید کد را دانلود کرده و محلی ادغام کنید، یا با دستور `git pull <url> <branch>` که قبلاً دیدیم، یا با افزودن فورک به عنوان remote و گرفتن و ادغام آن.
 
-If the merge is trivial, you can also just hit the "`Merge`" button on the GitHub site.
-This will do a "`non-fast-forward`" merge, creating a merge commit even if a fast-forward merge was possible.
-This means that no matter what, every time you hit the merge button, a merge commit is created.
-As you can see in <<_merge_button>>, GitHub gives you all of this information if you click the hint link.
+اگر ادغام ساده باشد، می‌توانید به سادگی روی دکمه «Merge» در سایت گیت‌هاب کلیک کنید.
+این کار یک ادغام «non-fast-forward» انجام می‌دهد، یعنی یک کامیت ادغام ایجاد می‌کند حتی اگر ادغام fast-forward ممکن باشد.
+این یعنی هر بار که دکمه merge را می‌زنید، یک کامیت ادغام ساخته می‌شود.
+همان‌طور که در <<_merge_button>> می‌بینید، گیت‌هاب همه این اطلاعات را اگر روی لینک راهنما کلیک کنید، به شما نشان می‌دهد.
 
 [[_merge_button]]
 .Merge button and instructions for merging a Pull Request manually
 image::images/maint-02-merge.png[Merge button and instructions for merging a Pull Request manually]
 
-If you decide you don't want to merge it, you can also just close the Pull Request and the person who opened it will be notified.
+اگر تصمیم گرفتید که نمی‌خواهید ادغام کنید، می‌توانید فقط درخواست Pull را ببندید و شخصی که آن را باز کرده است، مطلع خواهد شد.
 
 [[_pr_refs]]
-===== Pull Request Refs
+===== Pull Request Refs (ارجاعات درخواست Pull)
 
-If you're dealing with a *lot* of Pull Requests and don't want to add a bunch of remotes or do one time pulls every time, there is a neat trick that GitHub allows you to do.
-This is a bit of an advanced trick and we'll go over the details of this a bit more in <<ch10-git-internals#_refspec>>, but it can be pretty useful.
+گیت‌هاب در واقع شاخه‌های درخواست Pull را به عنوان شاخه‌های شبه (pseudo-branches) روی سرور تبلیغ می‌کند.
+به طور پیش‌فرض وقتی کلون می‌کنید آن‌ها را دریافت نمی‌کنید، اما به شکلی پنهان وجود دارند و می‌توانید به راحتی به آن‌ها دسترسی پیدا کنید.
 
-GitHub actually advertises the Pull Request branches for a repository as sort of pseudo-branches on the server.
-By default you don't get them when you clone, but they are there in an obscured way and you can access them pretty easily.
+برای نشان دادن این موضوع، از یک دستور سطح پایین (که اغلب به آن دستور «لوله‌کشی» یا plumbing گفته می‌شود و در <<ch10-git-internals#_plumbing_porcelain>> بیشتر درباره آن می‌خوانیم) به نام `ls-remote` استفاده می‌کنیم.
+این دستور معمولاً در عملیات روزمره گیت استفاده نمی‌شود اما مفید است برای اینکه به ما نشان دهد چه ارجاعاتی روی سرور وجود دارد.
 
-To demonstrate this, we're going to use a low-level command (often referred to as a "`plumbing`" command, which we'll read about more in <<ch10-git-internals#_plumbing_porcelain>>) called `ls-remote`.
-This command is generally not used in day-to-day Git operations but it's useful to show us what references are present on the server.
-
-If we run this command against the "`blink`" repository we were using earlier, we will get a list of all the branches and tags and other references in the repository.
+اگر این دستور را روی مخزن "`blink`" که قبلاً استفاده می‌کردیم اجرا کنیم، فهرستی از همه شاخه‌ها، تگ‌ها و ارجاعات دیگر در مخزن به ما می‌دهد.
 
 [source,console]
 ----
@@ -143,16 +140,15 @@ a5a7751a33b7e86c5e9bb07b26001bb17d775d1a	refs/pull/4/head
 31a45fc257e8433c8d8804e3e848cf61c9d3166c	refs/pull/4/merge
 ----
 
-Of course, if you're in your repository and you run `git ls-remote origin` or whatever remote you want to check, it will show you something similar to this.
+البته، اگر در مخزن خود باشید و دستور `git ls-remote origin` یا هر ریموت دیگری که می‌خواهید بررسی کنید را اجرا کنید، چیزی مشابه این مشاهده خواهید کرد.
 
-If the repository is on GitHub and you have any Pull Requests that have been opened, you'll get these references that are prefixed with `refs/pull/`.
-These are basically branches, but since they're not under `refs/heads/` you don't get them normally when you clone or fetch from the server -- the process of fetching ignores them normally.
+اگر مخزن روی GitHub باشد و هر درخواست Pull (Pull Request) باز شده‌ای داشته باشید، این ارجاعات را خواهید دید که با `refs/pull/` شروع می‌شوند. این‌ها اساساً شاخه هستند، اما چون زیر `refs/heads/` نیستند، معمولاً هنگام کلون کردن یا fetch گرفتن از سرور به شما نمایش داده نمی‌شوند — فرایند fetch معمولاً آن‌ها را نادیده می‌گیرد.
 
-There are two references per Pull Request - the one that ends in `/head` points to exactly the same commit as the last commit in the Pull Request branch.
-So if someone opens a Pull Request in our repository and their branch is named `bug-fix` and it points to commit `a5a775`, then in *our* repository we will not have a `bug-fix` branch (since that's in their fork), but we _will_ have `pull/<pr#>/head` that points to `a5a775`.
-This means that we can pretty easily pull down every Pull Request branch in one go without having to add a bunch of remotes.
+برای هر درخواست Pull دو ارجاع وجود دارد — ارجاعی که به `/head` ختم می‌شود دقیقاً به همان کامیتی اشاره می‌کند که آخرین کامیت در شاخه درخواست Pull است.
+پس اگر کسی در مخزن ما یک درخواست Pull باز کند و شاخه‌اش به نام `bug-fix` باشد و به کامیت `a5a775` اشاره کند، در *مخزن خودمان* شاخه‌ای به نام `bug-fix` نخواهیم داشت (چون آن در فورک آن‌ها است)، اما _داشتن_ ارجاع `pull/<pr#>/head` که به `a5a775` اشاره می‌کند، خواهیم داشت.
+این یعنی می‌توانیم به آسانی همه شاخه‌های درخواست Pull را یکجا دریافت کنیم بدون اینکه مجبور باشیم تعداد زیادی ریموت اضافه کنیم.
 
-Now, you could do something like fetching the reference directly.
+حالا، می‌توانید کاری مانند دریافت مستقیم ارجاع را انجام دهید.
 
 [source,console]
 ----
@@ -161,14 +157,14 @@ From https://github.com/libgit2/libgit2
  * branch            refs/pull/958/head -> FETCH_HEAD
 ----
 
-This tells Git, "`Connect to the `origin` remote, and download the ref named `refs/pull/958/head`.`"
-Git happily obeys, and downloads everything you need to construct that ref, and puts a pointer to the commit you want under `.git/FETCH_HEAD`.
-You can follow that up with `git merge FETCH_HEAD` into a branch you want to test it in, but that merge commit message looks a bit weird.
-Also, if you're reviewing a *lot* of pull requests, this gets tedious.
+این به Git می‌گوید: «`به ریموت `origin` وصل شو، و ارجاع به نام `refs/pull/958/head` را دانلود کن.`»
+Git با کمال میل این کار را انجام می‌دهد و همه چیز لازم برای ساختن آن ارجاع را دانلود می‌کند و اشاره‌گری به کامیتی که می‌خواهید را زیر `.git/FETCH_HEAD` قرار می‌دهد.
+شما می‌توانید بعد از آن با دستور `git merge FETCH_HEAD` این را در شاخه‌ای که می‌خواهید تست کنید ادغام کنید، اما پیام کامیت ادغام کمی عجیب به نظر می‌رسد.
+همچنین، اگر تعداد زیادی درخواست Pull را بررسی می‌کنید، این کار خسته‌کننده می‌شود.
 
-There's also a way to fetch _all_ of the pull requests, and keep them up to date whenever you connect to the remote.
-Open up `.git/config` in your favorite editor, and look for the `origin` remote.
-It should look a bit like this:
+یک روش هم برای دریافت _تمام_ درخواست‌های Pull و به‌روزرسانی آن‌ها هر بار که به ریموت وصل می‌شوید وجود دارد.
+فایل `.git/config` را در ویرایشگر مورد علاقه‌تان باز کنید و دنبال ریموت `origin` بگردید.
+باید چیزی شبیه به این باشد:
 
 [source,ini]
 ----
@@ -177,10 +173,10 @@ It should look a bit like this:
     fetch = +refs/heads/*:refs/remotes/origin/*
 ----
 
-That line that begins with `fetch =` is a "`refspec.`"
-It's a way of mapping names on the remote with names in your local `.git` directory.
-This particular one tells Git, "the things on the remote that are under `refs/heads` should go in my local repository under `refs/remotes/origin`."
-You can modify this section to add another refspec:
+خطی که با `fetch =` شروع می‌شود، یک "`refspec`" است.
+روشی برای نگاشت نام‌ها در ریموت با نام‌ها در دایرکتوری محلی `.git` شماست.
+این refspec خاص به Git می‌گوید: «مواردی که در ریموت زیر `refs/heads` هستند باید در مخزن محلی من زیر `refs/remotes/origin` ذخیره شوند.»
+می‌توانید این بخش را اصلاح کنید و یک refspec دیگر اضافه کنید:
 
 [source,ini]
 ----
@@ -190,8 +186,8 @@ You can modify this section to add another refspec:
     fetch = +refs/pull/*/head:refs/remotes/origin/pr/*
 ----
 
-That last line tells Git, "`All the refs that look like `refs/pull/123/head` should be stored locally like `refs/remotes/origin/pr/123`.`"
-Now, if you save that file, and do a `git fetch`:
+خط آخر به Git می‌گوید: «تمام ارجاع‌هایی که شبیه `refs/pull/123/head` هستند باید به صورت محلی مانند `refs/remotes/origin/pr/123` ذخیره شوند.»
+حالا اگر آن فایل را ذخیره کنید و دستور `git fetch` را اجرا کنید:
 
 [source,console]
 ----
@@ -203,8 +199,8 @@ $ git fetch
 # …
 ----
 
-Now all of the remote pull requests are represented locally with refs that act much like tracking branches; they're read-only, and they update when you do a fetch.
-This makes it super easy to try the code from a pull request locally:
+اکنون همه درخواست‌های Pull ریموت به صورت محلی با ارجاع‌هایی نمایش داده می‌شوند که مثل شاخه‌های پیگیری عمل می‌کنند؛ فقط خواندنی هستند و هر بار که fetch می‌کنید به‌روزرسانی می‌شوند.
+این کار بسیار ساده می‌کند تا کد یک درخواست Pull را به صورت محلی تست کنید:
 
 [source,console]
 ----
@@ -214,85 +210,85 @@ Branch pr/2 set up to track remote branch pr/2 from origin.
 Switched to a new branch 'pr/2'
 ----
 
-The eagle-eyed among you would note the `head` on the end of the remote portion of the refspec.
-There's also a `refs/pull/#/merge` ref on the GitHub side, which represents the commit that would result if you push the "`merge`" button on the site.
-This can allow you to test the merge before even hitting the button.
+کسانی که با دقت نگاه می‌کنند متوجه `head` در انتهای بخش ریموت refspec خواهند شد.
+همچنین یک ارجاع `refs/pull/#/merge` در سمت GitHub وجود دارد که نشان‌دهنده کامیتی است که در صورت زدن دکمه "`merge`" در سایت حاصل می‌شود.
+این امکان را فراهم می‌کند که قبل از زدن دکمه، ادغام را تست کنید.
 
-===== Pull Requests on Pull Requests
+===== Pull Requests on Pull Requests (درخواست‌های Pull روی درخواست‌های Pull)
 
-Not only can you open Pull Requests that target the main or `master` branch, you can actually open a Pull Request targeting any branch in the network.
-In fact, you can even target another Pull Request.
+شما می‌توانید نه تنها درخواست‌های Pull را به شاخه‌ی اصلی یا `master` ارسال کنید، بلکه در واقع می‌توانید درخواست Pull را به هر شاخه‌ای در شبکه هدف قرار دهید.
+در واقع، حتی می‌توانید یک درخواست Pull را هدف بگیرید.
 
-If you see a Pull Request that is moving in the right direction and you have an idea for a change that depends on it or you're not sure is a good idea, or you just don't have push access to the target branch, you can open a Pull Request directly to it.
+اگر درخواست Pull ای را دیدید که در مسیر درستی حرکت می‌کند و ایده‌ای برای تغییر دارید که به آن وابسته است، یا مطمئن نیستید که ایده‌ی خوبی باشد، یا دسترسی برای ارسال مستقیم به شاخه هدف را ندارید، می‌توانید مستقیماً درخواست Pull را به آن ارسال کنید.
 
-When you go to open a Pull Request, there is a box at the top of the page that specifies which branch you're requesting to pull to and which you're requesting to pull from.
-If you hit the "`Edit`" button at the right of that box you can change not only the branches but also which fork.
+وقتی می‌خواهید درخواست Pull باز کنید، در بالای صفحه جعبه‌ای وجود دارد که مشخص می‌کند شما درخواست ادغام از کدام شاخه به کدام شاخه را دارید.
+اگر روی دکمه‌ی "`Edit`" در سمت راست آن جعبه کلیک کنید، می‌توانید نه تنها شاخه‌ها بلکه فورک مورد نظر را نیز تغییر دهید.
 
 [[_pr_targets]]
 .Manually change the Pull Request target fork and branch
 image::images/maint-04-target.png[Manually change the Pull Request target fork and branch]
 
-Here you can fairly easily specify to merge your new branch into another Pull Request or another fork of the project.
+در اینجا می‌توانید به‌راحتی مشخص کنید که شاخه جدیدتان را به یک درخواست Pull دیگر یا فورک دیگری از پروژه ادغام کنید.
 
-==== Mentions and Notifications
+==== Mentions and Notifications (اشاره‌ها و اعلان‌ها)
 
-GitHub also has a pretty nice notifications system built in that can come in handy when you have questions or need feedback from specific individuals or teams.
+گیت‌هاب همچنین سیستم اعلان‌های بسیار خوبی دارد که وقتی سوالی دارید یا به بازخورد از افراد یا تیم‌های خاص نیاز دارید، بسیار مفید است.
 
-In any comment you can start typing a `@` character and it will begin to autocomplete with the names and usernames of people who are collaborators or contributors in the project.
+در هر کامنت می‌توانید کاراکتر `@` را تایپ کنید و گیت‌هاب شروع به تکمیل خودکار نام‌ها و نام‌کاربری افرادی می‌کند که همکار یا مشارکت‌کننده در پروژه هستند.
 
 .Start typing @ to mention someone
 image::images/maint-05-mentions.png[Start typing @ to mention someone]
 
-You can also mention a user who is not in that dropdown, but often the autocompleter can make it faster.
+همچنین می‌توانید کاربری را که در آن لیست نیست، به صورت دستی ذکر کنید، اما اغلب تکمیل خودکار کار را سریع‌تر می‌کند.
 
-Once you post a comment with a user mention, that user will be notified.
-This means that this can be a really effective way of pulling people into conversations rather than making them poll.
-Very often in  Pull Requests on GitHub people will pull in other people on their teams or in their company to review an Issue or Pull Request.
+پس از ارسال کامنت با ذکر کاربر، آن کاربر مطلع خواهد شد.
+این یعنی این روش می‌تواند بسیار مؤثر باشد برای جلب توجه افراد به مکالمات، به جای اینکه آن‌ها را مجبور به رصد کردن کنید.
+اغلب در درخواست‌های Pull در گیت‌هاب، افراد دیگر اعضای تیم یا شرکت خود را برای بررسی یک Issue یا Pull Request وارد گفتگو می‌کنند.
 
-If someone gets mentioned on a Pull Request or Issue, they will be "`subscribed`" to it and will continue getting notifications any time some activity occurs on it.
-You will also be subscribed to something if you opened it, if you're watching the repository or if you comment on something.
-If you no longer wish to receive notifications, there is an "`Unsubscribe`" button on the page you can click to stop receiving updates on it.
+اگر کسی در یک درخواست Pull یا Issue ذکر شود، به آن مورد "`subscribed`" می‌شود و هر بار که فعالیتی روی آن انجام شود، اعلان دریافت خواهد کرد.
+شما هم به مواردی که باز کرده‌اید، یا مخزن را دنبال می‌کنید، یا در آن نظر داده‌اید، به‌طور خودکار عضو می‌شوید.
+اگر دیگر نمی‌خواهید اعلان دریافت کنید، دکمه‌ی "`Unsubscribe`" در صفحه وجود دارد که می‌توانید با کلیک روی آن، دریافت به‌روزرسانی‌ها را متوقف کنید.
 
 .Unsubscribe from an Issue or Pull Request
 image::images/maint-06-unsubscribe.png[Unsubscribe from an Issue or Pull Request]
 
-===== The Notifications Page
+===== The Notifications Page (صفحه اعلان‌ها)
 
-When we mention "`notifications`" here with respect to GitHub, we mean a specific way that GitHub tries to get in touch with you when events happen and there are a few different ways you can configure them.
-If you go to the "`Notification center`" tab from the settings page, you can see some of the options you have.
+وقتی درباره‌ی "`اعلان‌ها`" در گیت‌هاب صحبت می‌کنیم، منظورمان روشی خاص است که گیت‌هاب برای اطلاع‌رسانی به شما هنگام رخ دادن رویدادها دارد و شما می‌توانید آن‌ها را به چند روش مختلف تنظیم کنید.
+اگر به تب "`Notification center`" در صفحه تنظیمات بروید، می‌توانید برخی از گزینه‌های موجود را ببینید.
 
 .Notification center options
 image::images/maint-07-notifications.png[Notification center options]
 
-The two choices are to get notifications over "`Email`" and over "`Web`" and you can choose either, neither or both for when you actively participate in things and for activity on repositories you are watching.
+دو گزینه اصلی دریافت اعلان‌ها از طریق "`ایمیل`" و "`وب`" هستند و می‌توانید برای زمانی که در فعالیت‌ها شرکت می‌کنید و فعالیت روی مخازنی که دنبال می‌کنید، هر دو، هیچ‌کدام یا یکی‌شان را انتخاب کنید.
 
-====== Web Notifications
+====== Web Notifications (اعلان‌های وب)
 
-Web notifications only exist on GitHub and you can only check them on GitHub.
-If you have this option selected in your preferences and a notification is triggered for you, you will see a small blue dot over your notifications icon at the top of your screen as seen in <<_not_center>>.
+اعلان‌های وب فقط در گیت‌هاب وجود دارند و فقط می‌توانید آن‌ها را در گیت‌هاب مشاهده کنید.
+اگر این گزینه را در تنظیمات خود فعال کرده باشید و اعلان جدیدی برای شما ایجاد شود، یک نقطه‌ی کوچک آبی روی آیکون اعلان‌ها در بالای صفحه ظاهر می‌شود، همان‌طور که در <<_not_center>> دیده می‌شود.
 
 [[_not_center]]
 .Notification center
 image::images/maint-08-notifications-page.png[Notification center]
 
-If you click on that, you will see a list of all the items you have been notified about, grouped by project.
-You can filter to the notifications of a specific project by clicking on its name in the left hand sidebar.
-You can also acknowledge the notification by clicking the checkmark icon next to any notification, or acknowledge _all_ of the notifications in a project by clicking the checkmark at the top of the group.
-There is also a mute button next to each checkmark that you can click to not receive any further notifications on that item.
+با کلیک روی آن، فهرستی از تمام مواردی که اعلان دریافت کرده‌اید، به تفکیک پروژه نمایش داده می‌شود.
+می‌توانید با کلیک روی نام پروژه در نوار کناری سمت چپ، اعلان‌های یک پروژه خاص را فیلتر کنید.
+همچنین می‌توانید با کلیک روی آیکون تیک کنار هر اعلان، آن را تأیید کنید، یا تمام اعلان‌های یک پروژه را با کلیک روی تیک بالای گروه تأیید نمایید.
+دکمه‌ی سایلنت (بی‌صدا) نیز کنار هر تیک وجود دارد که اگر کلیک کنید، دیگر اعلان‌های آن مورد خاص را دریافت نخواهید کرد.
 
-All of these tools are very useful for handling large numbers of notifications.
-Many GitHub power users will simply turn off email notifications entirely and manage all of their notifications through this screen.
+تمام این ابزارها برای مدیریت تعداد زیادی اعلان بسیار کاربردی هستند.
+بسیاری از کاربران حرفه‌ای گیت‌هاب، اعلان‌های ایمیل را کاملاً غیرفعال می‌کنند و تمام اعلان‌های خود را از طریق این صفحه مدیریت می‌کنند.
 
-====== Email Notifications
+====== Email Notifications (اعلان‌های ایمیل)
 
-Email notifications are the other way you can handle notifications through GitHub.
-If you have this turned on you will get emails for each notification.
-We saw examples of this in <<_email_notification>> and <<_email_pr>>.
-The emails will also be threaded properly, which is nice if you're using a threading email client.
+اعلان‌های ایمیل روش دیگری برای دریافت اعلان‌ها از طریق گیت‌هاب هستند.
+اگر این گزینه را فعال کنید، برای هر اعلان یک ایمیل دریافت خواهید کرد.
+ما نمونه‌هایی از این اعلان‌ها را در <<_email_notification>> و <<_email_pr>> دیدیم.
+ایمیل‌ها همچنین به‌صورت موضوع‌بندی شده (Threaded) ارسال می‌شوند، که اگر از کلاینت ایمیل با پشتیبانی از این قابلیت استفاده کنید، بسیار مناسب است.
 
-There is also a fair amount of metadata embedded in the headers of the emails that GitHub sends you, which can be really helpful for setting up custom filters and rules.
+علاوه بر این، مقدار قابل توجهی از فراداده (metadata) در هدرهای ایمیل‌هایی که گیت‌هاب ارسال می‌کند وجود دارد، که برای تنظیم فیلترها و قوانین سفارشی بسیار مفید است.
 
-For instance, if we look at the actual email headers sent to Tony in the email shown in <<_email_pr>>, we will see the following among the information sent:
+برای مثال، اگر به هدرهای ایمیل واقعی که به تونی در ایمیل نشان داده‌شده در <<_email_pr>> ارسال شده نگاه کنیم، اطلاعات زیر در میان داده‌های ارسالی دیده می‌شود:
 
 [source,mbox]
 ----
@@ -307,71 +303,71 @@ List-Unsubscribe: <mailto:unsub+i-XXX@reply.github.com>,...
 X-GitHub-Recipient-Address: tchacon@example.com
 ----
 
-There are a couple of interesting things here.
-If you want to highlight or re-route emails to this particular project or even Pull Request, the information in `Message-ID` gives you all the data in `<user>/<project>/<type>/<id>` format.
-If this was an issue, for example, the `<type>` field would have been "`issues`" rather than "`pull`".
+ چند نکته جالب در اینجا وجود دارد.
+اگر بخواهید ایمیل‌ها را به این پروژه خاص یا حتی درخواست پول (Pull Request) مشخصی هدایت یا برجسته کنید، اطلاعات موجود در `Message-ID` تمام داده‌ها را به فرمت `<user>/<project>/<type>/<id>` در اختیار شما قرار می‌دهد.
+برای مثال، اگر این یک مسئله (Issue) بود، فیلد `<type>` به جای "`pull`" مقدار "`issues`" را داشت.
 
-The `List-Post` and `List-Unsubscribe` fields mean that if you have a mail client that understands those, you can easily post to the list or "`Unsubscribe`" from the thread.
-That would be essentially the same as clicking the "`mute`" button on the web version of the notification or "`Unsubscribe`" on the Issue or Pull Request page itself.
+فیلدهای `List-Post` و `List-Unsubscribe` به این معنا هستند که اگر کلاینت ایمیل شما این قابلیت‌ها را پشتیبانی کند، به راحتی می‌توانید به لیست ایمیل ارسال کنید یا از دریافت این موضوع خاص لغو اشتراک کنید.
+این عملکرد عملاً معادل کلیک روی دکمه "`mute`" در نسخه وب اعلان یا گزینه "`Unsubscribe`" در صفحه Issue یا Pull Request است.
 
-It's also worth noting that if you have both email and web notifications enabled and you read the email version of the notification, the web version will be marked as read as well if you have images allowed in your mail client.
+همچنین شایان ذکر است که اگر اعلان‌های ایمیل و وب هر دو فعال باشند و شما نسخه ایمیلی اعلان را بخوانید، نسخه وب نیز به عنوان خوانده شده علامت‌گذاری می‌شود، البته به شرطی که در کلاینت ایمیل خود اجازه نمایش تصاویر را داده باشید.
 
-==== Special Files
+==== Special Files (فایل‌های ویژه)
 
-There are a couple of special files that GitHub will notice if they are present in your repository.
+چند فایل ویژه وجود دارند که اگر در مخزن شما باشند، گیت‌هاب آن‌ها را تشخیص می‌دهد.
 
 ==== README
 
-The first is the `README` file, which can be of nearly any format that GitHub recognizes as prose.
-For example, it could be `README`, `README.md`, `README.asciidoc`, etc.
-If GitHub sees a `README` file in your source, it will render it on the landing page of the project.
+اولین فایل `README` است که می‌تواند تقریباً هر فرمتی داشته باشد که گیت‌هاب به عنوان متن قابل خواندن بشناسد.
+مثلاً می‌تواند `README`، `README.md`، `README.asciidoc` و غیره باشد.
+اگر گیت‌هاب فایل `README` را در سورس شما ببیند، آن را در صفحه اصلی پروژه نمایش می‌دهد.
 
-Many teams use this file to hold all the relevant project information for someone who might be new to the repository or project.
-This generally includes things like:
+بسیاری از تیم‌ها از این فایل استفاده می‌کنند تا تمام اطلاعات مرتبط با پروژه را برای کسی که تازه با مخزن یا پروژه آشنا شده، ارائه دهند.
+معمولاً این اطلاعات شامل موارد زیر است:
 
-* What the project is for
-* How to configure and install it
-* An example of how to use it or get it running
-* The license that the project is offered under
-* How to contribute to it
+* هدف پروژه چیست
+* چگونه آن را پیکربندی و نصب کنیم
+* نمونه‌ای از نحوه استفاده یا اجرای آن
+* مجوزی که پروژه تحت آن عرضه شده است
+* نحوه مشارکت در پروژه
 
-Since GitHub will render this file, you can embed images or links in it for added ease of understanding.
+از آنجا که گیت‌هاب این فایل را نمایش می‌دهد، می‌توانید تصاویر یا لینک‌هایی در آن بگنجانید تا فهم آن آسان‌تر شود.
 
-==== CONTRIBUTING
+==== CONTRIBUTING (مشارکت)
 
-The other special file that GitHub recognizes is the `CONTRIBUTING` file.
-If you have a file named `CONTRIBUTING` with any file extension, GitHub will show <<_contrib_file>> when anyone starts opening a Pull Request.
+فایل ویژه دیگری که گیت‌هاب آن را تشخیص می‌دهد، فایل `CONTRIBUTING` است.
+اگر فایل `CONTRIBUTING` با هر پسوندی داشته باشید، گیت‌هاب زمانی که کسی درخواست پول جدیدی باز می‌کند، <<_contrib_file>> را نمایش می‌دهد.
 
 [[_contrib_file]]
 .Opening a Pull Request when a CONTRIBUTING file exists
 image::images/maint-09-contrib.png[Opening a Pull Request when a CONTRIBUTING file exists]
 
-The idea here is that you can specify specific things you want or don't want in a Pull Request sent to your project.
-This way people may actually read the guidelines before opening the Pull Request.
+ایده این است که شما می‌توانید قواعد خاصی که می‌خواهید یا نمی‌خواهید در یک Pull Request به پروژه شما ارسال شود را مشخص کنید.
+به این ترتیب، افراد احتمالاً قبل از باز کردن درخواست پول، دستورالعمل‌ها را مطالعه خواهند کرد.
 
-==== Project Administration
+==== Project Administration (مدیریت پروژه)
 
-Generally there are not a lot of administrative things you can do with a single project, but there are a couple of items that might be of interest.
+به طور کلی امکانات مدیریتی زیادی برای یک پروژه واحد وجود ندارد، اما چند مورد ممکن است برای شما جالب باشد.
 
-===== Changing the Default Branch
+===== Changing the Default Branch (تغییر شاخه پیش‌فرض)
 
-If you are using a branch other than "`master`" as your default branch that you want people to open Pull Requests on or see by default, you can change that in your repository's settings page under the "`Options`" tab.
+اگر شاخه‌ای غیر از "`master`" را به عنوان شاخه پیش‌فرض که می‌خواهید افراد روی آن درخواست پول باز کنند یا به صورت پیش‌فرض ببینند، استفاده می‌کنید، می‌توانید این تنظیم را در صفحه تنظیمات مخزن خود زیر تب "`Options`" تغییر دهید.
 
 [[_default_branch]]
 .Change the default branch for a project
 image::images/maint-10-default-branch.png[Change the default branch for a project]
 
-Simply change the default branch in the dropdown and that will be the default for all major operations from then on, including which branch is checked out by default when someone clones the repository.
+به سادگی شاخه پیش‌فرض را در منوی کشویی تغییر دهید و از آن پس تمام عملیات اصلی با آن شاخه به عنوان پیش‌فرض انجام خواهد شد، از جمله شاخه‌ای که هنگام کلون کردن مخزن به صورت پیش‌فرض بررسی می‌شود.
 
-===== Transferring a Project
+===== Transferring a Project (انتقال یک پروژه)
 
-If you would like to transfer a project to another user or an organization in GitHub, there is a "`Transfer ownership`" option at the bottom of the same "`Options`" tab of your repository settings page that allows you to do this.
+اگر بخواهید پروژه‌ای را به کاربر یا سازمان دیگری در گیت‌هاب منتقل کنید، گزینه‌ای با عنوان "`Transfer ownership`" در پایین همان تب "`Options`" در صفحه تنظیمات مخزن شما وجود دارد که این امکان را فراهم می‌کند.
 
 [[_transfer_project]]
 .Transfer a project to another GitHub user or Organization
 image::images/maint-11-transfer.png[Transfer a project to another GitHub user or Organization]
 
-This is helpful if you are abandoning a project and someone wants to take it over, or if your project is getting bigger and want to move it into an organization.
+این قابلیت زمانی مفید است که شما پروژه را رها می‌کنید و کسی می‌خواهد آن را به عهده بگیرد، یا پروژه شما بزرگ‌تر شده و می‌خواهید آن را به یک سازمان منتقل کنید.
 
-Not only does this move the repository along with all its watchers and stars to another place, it also sets up a redirect from your URL to the new place.
-It will also redirect clones and fetches from Git, not just web requests.
+این کار نه تنها مخزن را همراه با تمام دنبال‌کنندگان و ستاره‌های آن به مکان جدید منتقل می‌کند، بلکه یک ریدایرکت از URL قبلی شما به مکان جدید نیز ایجاد می‌کند.
+همچنین این ریدایرکت شامل کلون‌ها و دریافت‌ها از طریق گیت می‌شود، نه فقط درخواست‌های وب.

--- a/book/06-github/sections/4-managing-organization.asc
+++ b/book/06-github/sections/4-managing-organization.asc
@@ -1,72 +1,72 @@
 [[ch06-github_orgs]]
-=== Managing an organization
+=== Managing an organization (مدیریت یک سازمان)
 
 (((GitHub, organizations)))
-In addition to single-user accounts, GitHub has what are called Organizations.
-Like personal accounts, Organizational accounts have a namespace where all their projects exist, but many other things are different.
-These accounts represent a group of people with shared ownership of projects, and there are many tools to manage subgroups of those people.
-Normally these accounts are used for Open Source groups (such as "`perl`" or "`rails`") or companies (such as "`google`" or "`twitter`").
+علاوه بر حساب‌های کاربری تک‌نفره، گیت‌هاب چیزی به نام سازمان‌ها دارد.
+مانند حساب‌های شخصی، حساب‌های سازمانی یک فضای نام دارند که همه پروژه‌هایشان در آن قرار دارد، اما بسیاری از جنبه‌های دیگر متفاوت است.
+این حساب‌ها نماینده گروهی از افراد با مالکیت مشترک پروژه‌ها هستند و ابزارهای زیادی برای مدیریت زیرگروه‌های این افراد وجود دارد.
+معمولاً این حساب‌ها برای گروه‌های متن‌باز (مانند "`perl`" یا "`rails`") یا شرکت‌ها (مانند "`google`" یا "`twitter`") استفاده می‌شوند.
 
-==== Organization Basics
+==== اصول اولیه سازمان
 
-An organization is pretty easy to create; just click on the "`+`" icon at the top-right of any GitHub page, and select "`New organization`" from the menu.
+ایجاد یک سازمان بسیار آسان است؛ کافی است روی آیکون "`+`" در بالا و سمت راست هر صفحه گیت‌هاب کلیک کنید و از منو گزینه "`New organization`" را انتخاب کنید.
 
 .The "`New organization`" menu item
 image::images/neworg.png[The “New organization” menu item]
 
-First you'll need to name your organization and provide an email address for a main point of contact for the group.
-Then you can invite other users to be co-owners of the account if you want to.
+ابتدا باید نام سازمان خود را انتخاب کنید و یک آدرس ایمیل برای نقطه تماس اصلی گروه وارد نمایید.
+سپس می‌توانید در صورت تمایل دیگر کاربران را به عنوان هم‌مالک حساب دعوت کنید.
 
-Follow these steps and you'll soon be the owner of a brand-new organization.
-Like personal accounts, organizations are free if everything you plan to store there will be open source.
+با دنبال کردن این مراحل به زودی مالک یک سازمان کاملاً جدید خواهید بود.
+مانند حساب‌های شخصی، سازمان‌ها رایگان هستند اگر همه چیزهایی که قصد دارید در آن‌ها نگهداری کنید متن‌باز باشند.
 
-As an owner in an organization, when you fork a repository, you'll have the choice of forking it to your organization's namespace.
-When you create new repositories you can create them either under your personal account or under any of the organizations that you are an owner in.
-You also automatically "`watch`" any new repository created under these organizations.
+به عنوان مالک یک سازمان، وقتی مخزنی را فورک می‌کنید، می‌توانید انتخاب کنید که آن را به فضای نام سازمان خود فورک کنید.
+وقتی مخازن جدید ایجاد می‌کنید، می‌توانید آن‌ها را یا تحت حساب شخصی خود یا تحت هر یک از سازمان‌هایی که مالک آن هستید بسازید.
+همچنین به طور خودکار هر مخزن جدیدی که تحت این سازمان‌ها ایجاد شود را "`watch`" می‌کنید.
 
-Just like in <<_personal_avatar>>, you can upload an avatar for your organization to personalize it a bit.
-Also just like personal accounts, you have a landing page for the organization that lists all of your repositories and can be viewed by other people.
+دقیقاً مانند <<_personal_avatar>>، می‌توانید یک آواتار برای سازمان خود آپلود کنید تا کمی آن را شخصی‌سازی کنید.
+همچنین مانند حساب‌های شخصی، یک صفحه فرود برای سازمان دارید که تمام مخازن شما را فهرست می‌کند و دیگران می‌توانند آن را مشاهده کنند.
 
-Now let's cover some of the things that are a bit different with an organizational account.
+حال بیایید برخی از ویژگی‌هایی که در حساب سازمانی کمی متفاوت هستند را بررسی کنیم.
 
-==== Teams
+==== Teams (تیم ها)
 
-Organizations are associated with individual people by way of teams, which are simply a grouping of individual user accounts and repositories within the organization and what kind of access those people have in those repositories.
+سازمان‌ها از طریق تیم‌ها با افراد مرتبط می‌شوند، که در واقع گروه‌بندی حساب‌های کاربری فردی و مخازن درون سازمان و نوع دسترسی آن افراد به آن مخازن است.
 
-For example, say your company has three repositories: `frontend`, `backend`, and `deployscripts`.
-You'd want your HTML/CSS/JavaScript developers to have access to `frontend` and maybe `backend`, and your Operations people to have access to `backend` and `deployscripts`.
-Teams make this easy, without having to manage the collaborators for every individual repository.
+برای مثال، فرض کنید شرکت شما سه مخزن دارد: `frontend`، `backend` و `deployscripts`.
+شما می‌خواهید توسعه‌دهندگان HTML/CSS/JavaScript به `frontend` و شاید `backend` دسترسی داشته باشند، و تیم عملیات به `backend` و `deployscripts` دسترسی داشته باشند.
+تیم‌ها این کار را ساده می‌کنند، بدون اینکه مجبور باشید مشارکت‌کنندگان هر مخزن را به صورت جداگانه مدیریت کنید.
 
-The Organization page shows you a simple dashboard of all the repositories, users and teams that are under this organization.
+صفحه سازمان یک داشبورد ساده از تمام مخازن، کاربران و تیم‌هایی که زیر این سازمان هستند را به شما نشان می‌دهد.
 
 [[_org_page]]
 .The Organization page
 image::images/orgs-01-page.png[The Organization page]
 
-To manage your Teams, you can click on the Teams sidebar on the right hand side of the page in <<_org_page>>.
-This will bring you to a page you can use to add members to the team, add repositories to the team or manage the settings and access control levels for the team.
-Each team can have read only, read/write or administrative access to the repositories.
-You can change that level by clicking the "`Settings`" button in <<_team_page>>.
+برای مدیریت تیم‌های خود، می‌توانید در صفحه <<_org_page>> روی نوار کناری تیم‌ها در سمت راست صفحه کلیک کنید.
+این شما را به صفحه‌ای می‌برد که می‌توانید اعضا را به تیم اضافه کنید، مخازن را به تیم اضافه کنید یا تنظیمات و سطوح دسترسی تیم را مدیریت کنید.
+هر تیم می‌تواند دسترسی فقط خواندنی، خواندن/نوشتن یا دسترسی مدیریتی به مخازن داشته باشد.
+می‌توانید این سطح را با کلیک روی دکمه "`Settings`" در <<_team_page>> تغییر دهید.
 
 [[_team_page]]
 .The Team page
 image::images/orgs-02-teams.png[The Team page]
 
-When you invite someone to a team, they will get an email letting them know they've been invited.
+وقتی کسی را به تیم دعوت می‌کنید، ایمیلی دریافت می‌کند که اطلاع می‌دهد دعوت شده است.
 
-Additionally, team `@mentions` (such as `@acmecorp/frontend`) work much the same as they do with individual users, except that *all* members of the team are then subscribed to the thread.
-This is useful if you want the attention from someone on a team, but you don't know exactly who to ask.
+علاوه بر این، اشاره به تیم‌ها با `@mention` (مانند `@acmecorp/frontend`) تقریباً همانند اشاره به کاربران فردی عمل می‌کند، با این تفاوت که *تمام* اعضای تیم در آن بحث عضو می‌شوند.
+این ویژگی زمانی مفید است که می‌خواهید توجه کسی از تیم را جلب کنید ولی دقیقاً نمی‌دانید از چه کسی باید سؤال کنید.
 
-A user can belong to any number of teams, so don't limit yourself to only access-control teams.
-Special-interest teams like `ux`, `css`, or `refactoring` are useful for certain kinds of questions, and others like `legal` and `colorblind` for an entirely different kind.
+یک کاربر می‌تواند عضو هر تعداد تیم باشد، پس خود را محدود به تیم‌های صرفاً کنترل دسترسی نکنید.
+تیم‌های علاقه‌مند خاص مانند `ux`، `css` یا `refactoring` برای نوع خاصی از سوالات مفید هستند و تیم‌هایی مانند `legal` و `colorblind` برای موضوعات کاملاً متفاوت کاربرد دارند.
 
-==== Audit Log
+==== Audit Log (گزارش بازرسی)
 
-Organizations also give owners access to all the information about what went on under the organization.
-You can go to the 'Audit Log' tab and see what events have happened at an organization level, who did them and where in the world they were done.
+سازمان‌ها همچنین به مالکین دسترسی به تمام اطلاعات مربوط به اتفاقاتی که در سازمان رخ داده را می‌دهند.
+می‌توانید به تب 'Audit Log' بروید و ببینید چه رویدادهایی در سطح سازمان اتفاق افتاده، چه کسی آن‌ها را انجام داده و در کجا در جهان انجام شده‌اند.
 
 [[_the_audit_log]]
 .The Audit log
 image::images/orgs-03-audit.png[The Audit log]
 
-You can also filter down to specific types of events, specific places or specific people.
+همچنین می‌توانید بر اساس نوع خاصی از رویدادها، مکان‌های خاص یا افراد خاص فیلتر کنید.

--- a/book/06-github/sections/5-scripting.asc
+++ b/book/06-github/sections/5-scripting.asc
@@ -1,63 +1,63 @@
-=== Scripting GitHub
+=== Scripting GitHub (اسکریپتنویسی در گیتهاب)
 
-So now we've covered all of the major features and workflows of GitHub, but any large group or project will have customizations they may want to make or external services they may want to integrate.
+حالا که همهٔ ویژگیها و روندهای اصلی گیتهاب را بررسی کردیم، هر گروه یا پروژهٔ بزرگی ممکن است بخواهد تغییرات سفارشی یا سرویسهای خارجی خاصی را به آن اضافه کند.
 
-Luckily for us, GitHub is really quite hackable in many ways.
-In this section we'll cover how to use the GitHub hooks system and its API to make GitHub work how we want it to.
+خوشبختانه، گیتهاب به طرق مختلف بسیار قابل تنظیم است.
+در این بخش، نحوهٔ استفاده از سیستم هوکهای گیتهاب و API آن را بررسی میکنیم تا گیتهاب را مطابق خواستههایمان به کار بگیریم.
 
-==== Services and Hooks
+==== Services and Hooks (سرویسها و هوکها)
 
-The Hooks and Services section of GitHub repository administration is the easiest way to have GitHub interact with external systems.
+بخش هوکها و سرویسها در مدیریت مخزن گیتهاب سادهترین راه برای تعامل گیتهاب با سیستمهای خارجی است.
 
-===== Services
+===== Services (سرویسها)
 
-First we'll take a look at Services.
-Both the Hooks and Services integrations can be found in the Settings section of your repository, where we previously looked at adding Collaborators and changing the default branch of your project.
-Under the "`Webhooks and Services`" tab you will see something like <<_services_hooks>>.
+ابتدا نگاهی به سرویسها میاندازیم.
+هر دو نوع ادغام هوکها و سرویسها را میتوانید در بخش تنظیمات مخزن خود پیدا کنید؛ جایی که قبلاً افزودن همکاران و تغییر شاخه پیشفرض پروژه را بررسی کردیم.
+در تب «Webhooks and Services» چیزی شبیه <<_services_hooks>> مشاهده خواهید کرد.
 
 [[_services_hooks]]
 .Services and Hooks configuration section
 image::images/scripting-01-services.png[Services and Hooks configuration section]
 
-There are dozens of services you can choose from, most of them integrations into other commercial and open source systems.
-Most of them are for Continuous Integration services, bug and issue trackers, chat room systems and documentation systems.
-We'll walk through setting up a very simple one, the Email hook.
-If you choose "`email`" from the "`Add Service`" dropdown, you'll get a configuration screen like <<_service_config>>.
+دهها سرویس مختلف برای انتخاب وجود دارد که بیشتر آنها ادغام با سیستمهای تجاری و متنباز دیگر هستند.
+اکثر آنها برای خدمات یکپارچهسازی مداوم، ردیابهای اشکال و مسائل، سیستمهای چت گروهی و مستندسازی کاربرد دارند.
+ما با راهاندازی یک سرویس بسیار ساده، یعنی هوک ایمیل، پیش میرویم.
+اگر از منوی کشویی "`Add Service`" گزینه "`email`" را انتخاب کنید، صفحه تنظیمات مانند <<_service_config>> ظاهر میشود.
 
 [[_service_config]]
 .Email service configuration
 image::images/scripting-02-email-service.png[Email service configuration]
 
-In this case, if we hit the "`Add service`" button, the email address we specified will get an email every time someone pushes to the repository.
-Services can listen for lots of different types of events, but most only listen for push events and then do something with that data.
+در این حالت، اگر روی دکمه «Add service» کلیک کنیم، آدرس ایمیلی که مشخص کردهایم هر بار که کسی به مخزن پوش کند، ایمیلی دریافت خواهد کرد.
+سرویسها میتوانند به انواع مختلفی از رویدادها گوش دهند، اما بیشترشان فقط به رویدادهای پوش حساساند و سپس کاری با آن دادهها انجام میدهند.
 
-If there is a system you are using that you would like to integrate with GitHub, you should check here to see if there is an existing service integration available.
-For example, if you're using Jenkins to run tests on your codebase, you can enable the Jenkins builtin service integration to kick off a test run every time someone pushes to your repository.
+اگر سیستمی دارید که میخواهید با گیتهاب ادغام کنید، ابتدا اینجا را بررسی کنید تا ببینید آیا ادغام سرویس موجود هست یا نه.
+برای مثال، اگر از Jenkins برای اجرای تستهای کد خود استفاده میکنید، میتوانید سرویس داخلی Jenkins را فعال کنید تا هر بار که کسی به مخزن شما پوش میکند، یک اجرای تست شروع شود.
 
-===== Hooks
+===== Hooks (هوکها)
 
-If you need something more specific or you want to integrate with a service or site that is not included in this list, you can instead use the more generic hooks system.
-GitHub repository hooks are pretty simple.
-You specify a URL and GitHub will post an HTTP payload to that URL on any event you want.
+اگر به چیزی خاصتر نیاز دارید یا میخواهید با سرویسی یا سایتی که در این فهرست نیست ادغام کنید، میتوانید از سیستم عمومیتر هوکها استفاده کنید.
+هوکهای مخزن گیتهاب بسیار سادهاند.
+شما یک URL مشخص میکنید و گیتهاب در هر رویدادی که بخواهید، یک بارگذاری HTTP به آن URL ارسال میکند.
 
-Generally the way this works is you can setup a small web service to listen for a GitHub hook payload and then do something with the data when it is received.
+معمولاً این کار به این شکل انجام میشود که یک سرویس وب کوچک راهاندازی میکنید تا به بارگذاری هوک گیتهاب گوش دهد و سپس وقتی داده دریافت شد، کاری با آن انجام دهد.
 
-To enable a hook, you click the "`Add webhook`" button in <<_services_hooks>>.
-This will bring you to a page that looks like <<_web_hook>>.
+برای فعالسازی یک هوک، روی دکمه "`Add webhook`" در <<_services_hooks>> کلیک کنید.
+این شما را به صفحهای مانند <<_web_hook>> میبرد.
 
 [[_web_hook]]
 .Web hook configuration
 image::images/scripting-03-webhook.png[Web hook configuration]
 
-The configuration for a web hook is pretty simple.
-In most cases you simply enter a URL and a secret key and hit "`Add webhook`".
-There are a few options for which events you want GitHub to send you a payload for -- the default is to only get a payload for the `push` event, when someone pushes new code to any branch of your repository.
+تنظیمات یک وب هوک بسیار ساده است.
+معمولاً کافی است یک URL و کلید مخفی وارد کنید و روی "`Add webhook`" کلیک کنید.
+چند گزینه برای انتخاب رویدادهایی که میخواهید گیتهاب برایشان بارگذاری ارسال کند وجود دارد — پیشفرض این است که فقط بارگذاری برای رویداد `push` دریافت کنید، یعنی وقتی کسی کد جدیدی به هر شاخهای از مخزن شما پوش میکند.
 
-Let's see a small example of a web service you may set up to handle a web hook.
-We'll use the Ruby web framework Sinatra since it's fairly concise and you should be able to easily see what we're doing.
+بیایید یک مثال کوچک از سرویس وبی که ممکن است برای مدیریت یک وب هوک راهاندازی کنید ببینیم.
+ما از فریمورک وب Ruby به نام Sinatra استفاده میکنیم چون بسیار مختصر است و به راحتی میتوانید کاری که انجام میدهیم را ببینید.
 
-Let's say we want to get an email if a specific person pushes to a specific branch of our project modifying a specific file.
-We could fairly easily do that with code like this:
+فرض کنیم میخواهیم وقتی شخص خاصی به شاخه خاصی از پروژه ما پوش میکند و یک فایل خاص را تغییر میدهد، ایمیلی دریافت کنیم.
+میتوانیم این کار را به سادگی با کدی مانند این انجام دهیم:
 
 [source,ruby]
 ----
@@ -93,37 +93,37 @@ post '/payload' do
 end
 ----
 
-Here we're taking the JSON payload that GitHub delivers us and looking up who pushed it, what branch they pushed to and what files were touched in all the commits that were pushed.
-Then we check that against our criteria and send an email if it matches.
+اینجا، ما بارگذاری JSON را که گیتهاب ارسال میکند دریافت میکنیم و بررسی میکنیم چه کسی پوش کرده، به کدام شاخه پوش شده و چه فایلهایی در همهٔ کامیتهای پوش شده تغییر کردهاند.
+سپس آن را با معیارهای خود مقایسه میکنیم و اگر تطابق داشت، ایمیل ارسال میکنیم.
 
-In order to develop and test something like this, you have a nice developer console in the same screen where you set the hook up.
-You can see the last few deliveries that GitHub has tried to make for that webhook.
-For each hook you can dig down into when it was delivered, if it was successful and the body and headers for both the request and the response.
-This makes it incredibly easy to test and debug your hooks.
+برای توسعه و آزمایش چنین چیزی، یک کنسول توسعهدهندهٔ خوب در همان صفحه راهاندازی هوک دارید.
+میتوانید آخرین چند بارگذاری که گیتهاب سعی کرده به آن هوک ارسال کند را ببینید.
+برای هر هوک میتوانید جزئیات زمان ارسال، موفقیتآمیز بودن، بدنه و هدرهای درخواست و پاسخ را بررسی کنید.
+این باعث میشود تست و اشکالزدایی هوکها بسیار آسان شود.
 
 [[_web_hook_debug]]
 .Web hook debugging information
 image::images/scripting-04-webhook-debug.png[Web hook debugging information]
 
-The other great feature of this is that you can redeliver any of the payloads to test your service easily.
+ویژگی عالی دیگر این است که میتوانید هر یک از بارگذاریها را دوباره ارسال کنید تا سرویس خود را به راحتی آزمایش کنید.
 
-For more information on how to write webhooks and all the different event types you can listen for, go to the GitHub Developer documentation at https://docs.github.com/en/webhooks-and-events/webhooks/about-webhooks[^].
+برای اطلاعات بیشتر دربارهٔ نحوهٔ نوشتن وب هوکها و انواع مختلف رویدادهایی که میتوانید به آنها گوش دهید، به مستندات توسعهدهندگان گیتهاب در https://docs.github.com/en/webhooks-and-events/webhooks/about-webhooks[^] مراجعه کنید.
 
-==== The GitHub API
+==== The GitHub API (API گیتهاب)
 
 (((GitHub, API)))
-Services and hooks give you a way to receive push notifications about events that happen on your repositories, but what if you need more information about these events?
-What if you need to automate something like adding collaborators or labeling issues?
+سرویسها و هوکها به شما این امکان را میدهند که اعلانهایی دربارهٔ رویدادهای رخداده در مخازن خود دریافت کنید، اما اگر نیاز به اطلاعات بیشتری دربارهٔ این رویدادها داشته باشید چه؟
+اگر بخواهید کارهایی مانند افزودن همکار یا برچسبگذاری مسائل را به صورت خودکار انجام دهید چه؟
 
-This is where the GitHub API comes in handy.
-GitHub has tons of API endpoints for doing nearly anything you can do on the website in an automated fashion.
-In this section we'll learn how to authenticate and connect to the API, how to comment on an issue and how to change the status of a Pull Request through the API.
+در اینجا API گیتهاب به کمک شما میآید.
+گیتهاب تعداد زیادی نقطهٔ پایانی (endpoint) API دارد که تقریباً هر کاری را که میتوانید روی وبسایت انجام دهید به صورت خودکار امکانپذیر میکند.
+در این بخش یاد میگیریم چگونه احراز هویت کنیم و به API متصل شویم، چگونه روی یک مسئله نظر بگذاریم و چگونه وضعیت یک Pull Request را از طریق API تغییر دهیم.
 
-==== Basic Usage
+==== Basic Usage (استفادهٔ پایه)
 
-The most basic thing you can do is a simple GET request on an endpoint that doesn't require authentication.
-This could be a user or read-only information on an open source project.
-For example, if we want to know more about a user named "`schacon`", we can run something like this:
+سادهترین کاری که میتوانید انجام دهید، درخواست GET ساده به نقطه پایانی است که نیاز به احراز هویت ندارد.
+این میتواند اطلاعات یک کاربر یا دادههای فقط خواندنی دربارهٔ یک پروژه متنباز باشد.
+برای مثال، اگر بخواهیم دربارهٔ کاربری به نام "`schacon`" اطلاعات بیشتری بدانیم، میتوانیم چیزی شبیه این اجرا کنیم:
 
 [source,javascript]
 ----
@@ -141,8 +141,8 @@ $ curl https://api.github.com/users/schacon
 }
 ----
 
-There are tons of endpoints like this to get information about organizations, projects, issues, commits -- just about anything you can publicly see on GitHub.
-You can even use the API to render arbitrary Markdown or find a `.gitignore` template.
+ تعداد بسیار زیادی نقطه انتهایی (endpoint) مانند این وجود دارد که میتوانید از طریق آنها اطلاعات مربوط به سازمانها، پروژهها، مسائل، کامیتها — تقریباً هر چیزی که بهصورت عمومی روی گیتهاب قابل مشاهده است — را دریافت کنید.
+حتی میتوانید از API برای رندر کردن Markdown دلخواه یا پیدا کردن قالب `.gitignore` استفاده کنید.
 
 [source,javascript]
 ----
@@ -165,32 +165,32 @@ hs_err_pid*
 }
 ----
 
-==== Commenting on an Issue
+==== Commenting on an Issue (نظر دادن درباره یک Issue)
 
-However, if you want to do an action on the website such as comment on an Issue or Pull Request or if you want to view or interact with private content, you'll need to authenticate.
+با این حال، اگر بخواهید عملی روی وبسایت انجام دهید، مانند نظر دادن درباره یک Issue یا Pull Request، یا اگر بخواهید محتوای خصوصی را مشاهده یا با آن تعامل کنید، باید احراز هویت کنید.
 
-There are several ways to authenticate.
-You can use basic authentication with just your username and password, but generally it's a better idea to use a personal access token.
-You can generate this from the "`Applications`" tab of your settings page.
+روشهای مختلفی برای احراز هویت وجود دارد.
+میتوانید از احراز هویت پایه تنها با نام کاربری و رمز عبور خود استفاده کنید، اما معمولاً بهتر است از یک توکن دسترسی شخصی استفاده کنید.
+میتوانید این توکن را از تب «Applications» در صفحه تنظیمات خود ایجاد کنید.
 
 [[_access_token]]
 .Generate your access token from the "`Applications`" tab of your settings page
 image::images/scripting-05-access-token.png[Generate your access token from the “Applications” tab of your settings page]
 
-It will ask you which scopes you want for this token and a description.
-Make sure to use a good description so you feel comfortable removing the token when your script or application is no longer used.
+از شما خواسته میشود که دامنههای دسترسی (scopes) مورد نیاز برای این توکن و توضیحی درباره آن را مشخص کنید.
+حتماً توضیح مناسبی بنویسید تا وقتی اسکریپت یا برنامه شما دیگر استفاده نشد، راحت بتوانید توکن را حذف کنید.
 
-GitHub will only show you the token once, so be sure to copy it.
-You can now use this to authenticate in your script instead of using a username and password.
-This is nice because you can limit the scope of what you want to do and the token is revocable.
+GitHub این توکن را فقط یک بار به شما نشان میدهد، پس حتماً آن را کپی کنید.
+اکنون میتوانید به جای استفاده از نام کاربری و رمز عبور، از این توکن برای احراز هویت در اسکریپت خود استفاده کنید.
+این روش خوب است چون میتوانید دامنههای دسترسی را محدود کنید و توکن قابل لغو است.
 
-This also has the added advantage of increasing your rate limit.
-Without authenticating, you will be limited to 60 requests per hour.
-If you authenticate you can make up to 5,000 requests per hour.
+این روش مزیت دیگری هم دارد که محدودیت نرخ درخواست شما را افزایش میدهد.
+اگر احراز هویت نکنید، محدود به ۶۰ درخواست در ساعت خواهید بود.
+اما با احراز هویت میتوانید تا ۵۰۰۰ درخواست در ساعت ارسال کنید.
 
-So let's use it to make a comment on one of our issues.
-Let's say we want to leave a comment on a specific issue, Issue #6.
-To do so we have to do an HTTP POST request to `repos/<user>/<repo>/issues/<num>/comments` with the token we just generated as an Authorization header.
+پس بیایید از این روش برای گذاشتن نظر روی یکی از Issues خود استفاده کنیم.
+فرض کنیم میخواهیم نظر روی یک Issue مشخص، مثلاً Issue شماره ۶، بگذاریم.
+برای این کار باید یک درخواست HTTP POST به آدرس repos/<user>/<repo>/issues/<num>/comments با توکنی که ایجاد کردیم، به عنوان هدر Authorization ارسال کنیم.
 
 [source,javascript]
 ----
@@ -214,23 +214,23 @@ $ curl -H "Content-Type: application/json" \
 }
 ----
 
-Now if you go to that issue, you can see the comment that we just successfully posted as in <<_api_comment>>.
+حالا اگر به آن Issue بروید، میتوانید نظر موفقیتآمیز خود را مشاهده کنید.
 
 [[_api_comment]]
 .A comment posted from the GitHub API
 image::images/scripting-06-comment.png[A comment posted from the GitHub API]
 
-You can use the API to do just about anything you can do on the website -- creating and setting milestones, assigning people to Issues and Pull Requests, creating and changing labels, accessing commit data, creating new commits and branches, opening, closing or merging Pull Requests, creating and editing teams, commenting on lines of code in a Pull Request, searching the site and on and on.
+میتوانید با API تقریباً هر کاری که در وبسایت میتوانید انجام دهید، انجام دهید — ایجاد و تنظیم milestones، اختصاص دادن افراد به Issues و Pull Requests، ایجاد و تغییر برچسبها، دسترسی به دادههای commit، ایجاد commit و branch جدید، باز کردن، بستن یا ادغام Pull Requests، ایجاد و ویرایش تیمها، نظر دادن روی خطوط کد در یک Pull Request، جستجو در سایت و غیره.
 
-==== Changing the Status of a Pull Request
+==== Changing the Status of a Pull Request (تغییر وضعیت یک Pull Request)
 
-There is one final example we'll look at since it's really useful if you're working with Pull Requests.
-Each commit can have one or more statuses associated with it and there is an API to add and query that status.
+یک مثال نهایی که بسیار مفید است اگر با Pull Requests کار میکنید، بررسی میکنیم.
+هر commit میتواند یک یا چند وضعیت (status) مرتبط داشته باشد و API وجود دارد که میتوانید این وضعیتها را اضافه یا بررسی کنید.
 
-Most of the Continuous Integration and testing services make use of this API to react to pushes by testing the code that was pushed, and then report back if that commit has passed all the tests.
-You could also use this to check if the commit message is properly formatted, if the submitter followed all your contribution guidelines, if the commit was validly signed -- any number of things.
+اکثر سرویسهای Continuous Integration و تست از این API استفاده میکنند تا بعد از push کردن، کد را تست کنند و سپس گزارش دهند که آیا commit مورد نظر همه تستها را گذرانده است یا خیر.
+شما همچنین میتوانید از این روش استفاده کنید تا بررسی کنید که آیا پیام commit به درستی فرمت شده، آیا ارسالکننده همه دستورالعملهای مشارکت را رعایت کرده، آیا commit به درستی امضا شده — هر تعداد چیز دیگر.
 
-Let's say you set up a webhook on your repository that hits a small web service that checks for a `Signed-off-by` string in the commit message.
+فرض کنید یک webhook روی مخزن خود تنظیم کردهاید که به یک سرویس وب کوچک ضربه میزند و بررسی میکند که آیا در پیام commit عبارت «Signed-off-by» وجود دارد یا خیر.
 
 [source,ruby]
 ----
@@ -275,27 +275,27 @@ post '/payload' do
 end
 ----
 
-Hopefully this is fairly simple to follow.
-In this web hook handler we look through each commit that was just pushed, we look for the string 'Signed-off-by' in the commit message and finally we POST via HTTP to the `/repos/<user>/<repo>/statuses/<commit_sha>` API endpoint with the status.
+امیدوارم این موضوع نسبتاً ساده باشد.
+در این webhook handler، هر commit که تازه push شده را بررسی میکنیم، به دنبال عبارت «Signed-off-by» در پیام commit میگردیم و در نهایت با یک درخواست HTTP POST به endpoint /repos/<user>/<repo>/statuses/<commit_sha> وضعیت را ارسال میکنیم.
 
-In this case you can send a state ('success', 'failure', 'error'), a description of what happened, a target URL the user can go to for more information and a "`context`" in case there are multiple statuses for a single commit.
-For example, a testing service may provide a status and a validation service like this may also provide a status -- the "`context`" field is how they're differentiated.
+در این حالت میتوانید یک state ('success'، 'failure'، 'error')، توضیحی درباره اتفاقی که افتاده، یک URL هدف که کاربر میتواند برای اطلاعات بیشتر به آن مراجعه کند و یک «context» ارسال کنید تا اگر برای یک commit چند وضعیت وجود داشت، آنها از هم متمایز شوند.
+برای مثال، یک سرویس تست ممکن است یک وضعیت ارائه دهد و یک سرویس اعتبارسنجی مانند این نیز وضعیت دیگری بدهد — فیلد «context» برای تمایز بین آنهاست.
 
-If someone opens a new Pull Request on GitHub and this hook is set up, you may see something like <<_commit_status>>.
+اگر کسی یک Pull Request جدید در GitHub باز کند و این webhook تنظیم شده باشد، ممکن است چیزی شبیه <<_commit_status>> ببینید.
 
 [[_commit_status]]
 .Commit status via the API
 image::images/scripting-07-status.png[Commit status via the API]
 
-You can now see a little green check mark next to the commit that has a "`Signed-off-by`" string in the message and a red cross through the one where the author forgot to sign off.
-You can also see that the Pull Request takes the status of the last commit on the branch and warns you if it is a failure.
-This is really useful if you're using this API for test results so you don't accidentally merge something where the last commit is failing tests.
+اکنون میتوانید یک علامت تأیید سبز کوچک کنار commit که در پیام آن عبارت «Signed-off-by» وجود دارد ببینید و یک علامت ضربدر قرمز روی آن که نویسنده فراموش کرده امضا کند.
+همچنین مشاهده میکنید که Pull Request وضعیت آخرین commit روی شاخه را گرفته و اگر آن وضعیت failure باشد به شما هشدار میدهد.
+این بسیار مفید است اگر از این API برای نتایج تست استفاده میکنید تا به اشتباه چیزی را که آخرین commit آن تستها را رد کرده، ادغام نکنید.
 
 ==== Octokit
 
-Though we've been doing nearly everything through `curl` and simple HTTP requests in these examples, several open-source libraries exist that make this API available in a more idiomatic way.
-At the time of this writing, the supported languages include Go, Objective-C, Ruby, and .NET.
-Check out https://github.com/octokit[^] for more information on these, as they handle much of the HTTP for you.
+اگرچه در این مثالها تقریباً همه کارها را با curl و درخواستهای ساده HTTP انجام دادهایم، چندین کتابخانه متنباز وجود دارد که این API را به شکلی طبیعیتر در اختیار شما قرار میدهند.
+در زمان نگارش این متن، زبانهای پشتیبانی شده شامل Go، Objective-C، Ruby و .NET هستند.
+برای اطلاعات بیشتر به https://github.com/octokit[^] مراجعه کنید، زیرا این کتابخانهها بخش عمدهای از کارهای HTTP را برای شما مدیریت میکنند.
 
-Hopefully these tools can help you customize and modify GitHub to work better for your specific workflows.
-For complete documentation on the entire API as well as guides for common tasks, check out https://docs.github.com/[^].
+امیدوارم این ابزارها به شما کمک کنند تا GitHub را بهتر و متناسب با جریان کاری خاص خودتان سفارشی کنید.
+برای مستندات کامل تمام API و راهنمایی برای کارهای معمول، به https://docs.github.com/[^] مراجعه کنید.


### PR DESCRIPTION
This pull request primarily updates the Persian translation for the GitHub account setup and project maintenance documentation, improving clarity and localization for Persian-speaking users. It also includes minor updates to project workspace metadata to reflect recent activity and branch usage.

**Documentation localization and improvements:**

* Fully revised and localized Persian translation for the `book/06-github/sections/1-setting-up-account.asc` file, including all sections on account setup, SSH access, avatar management, email addresses, and two-factor authentication. The translation is more idiomatic and user-friendly for Persian readers.
* Added Persian translation for the section header and introductory paragraph in `book/06-github/sections/3-maintaining.asc`, clarifying repository creation steps for Persian readers.

**Workspace and project metadata updates:**

* Updated `.idea/workspace.xml` to reflect changes in tracked files, recent branch usage (including new branches and removal of old ones), and branch cleanup history. This helps keep the development environment organized and up-to-date. [[1]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL8-R9) [[2]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cR45-R55) [[3]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cR67-R70) [[4]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL63-L70)
* Changed the default branch for the Git widget placeholder from `book/translation/05-distributed-git` to `book/translation/06-github`, reflecting a shift in focus to the GitHub chapter.
* Added new work session entries to the workspace metadata, recording recent development activity.