### PR TITLE
translate(08-customizing-git): translated attributes to persian

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="" />
+    <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/book/08-customizing-git/sections/config.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/08-customizing-git/sections/config.asc" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -111,25 +114,25 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ModuleVcsDetector.initialDetectionPerformed": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "book/translation/08-customizing-git",
-    "junie.onboarding.icon.badge.shown": "true",
-    "last_opened_file_path": "/Users/mac/Projects/WebstormProjects/Github/progit2-fa",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "settings.editor.selected.configurable": "preferences.keymap",
-    "to.speed.mode.migration.done": "true",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;book/translation/08-customizing-git&quot;,
+    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/mac/Projects/WebstormProjects/Github/progit2-fa&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.keymap&quot;,
+    &quot;to.speed.mode.migration.done&quot;: &quot;true&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="SharedIndexes">
     <attachedChunks>
       <set>
@@ -164,6 +167,8 @@
       <workItem from="1756368644161" duration="6608000" />
       <workItem from="1756651368180" duration="1278000" />
       <workItem from="1756797841758" duration="2249000" />
+      <workItem from="1757231700506" duration="1734000" />
+      <workItem from="1757333632682" duration="1080000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/book/08-customizing-git/sections/config.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/08-customizing-git/sections/config.asc" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/book/08-customizing-git/sections/policy.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/08-customizing-git/sections/policy.asc" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -63,6 +62,17 @@
                 </list>
               </option>
               <option name="timestamp" value="1756802434019" />
+            </BranchCleanupEntry>
+            <BranchCleanupEntry>
+              <option name="deletions">
+                <list>
+                  <BranchDeletion>
+                    <option name="hash" value="bb3ea50eebfecd6c39ae477e7e9a2ed3005988d4" />
+                    <option name="name" value="book/translation/07-git-tools" />
+                  </BranchDeletion>
+                </list>
+              </option>
+              <option name="timestamp" value="1757403446258" />
             </BranchCleanupEntry>
           </list>
         </option>
@@ -169,6 +179,7 @@
       <workItem from="1756797841758" duration="2249000" />
       <workItem from="1757231700506" duration="1734000" />
       <workItem from="1757333632682" duration="1080000" />
+      <workItem from="1757343642265" duration="5688000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/book/07-git-tools/sections/submodules.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/07-git-tools/sections/submodules.asc" afterDir="false" />
-    </list>
+    <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -76,12 +73,12 @@
               <option name="branches">
                 <list>
                   <RecentBranch>
-                    <option name="branchName" value="book/translation/07-git-tools" />
-                    <option name="lastUsedInstant" value="1755687743" />
+                    <option name="branchName" value="book/translation/08-customizing-git" />
+                    <option name="lastUsedInstant" value="1756889525" />
                   </RecentBranch>
                   <RecentBranch>
-                    <option name="branchName" value="book/translation/06-github" />
-                    <option name="lastUsedInstant" value="1755449148" />
+                    <option name="branchName" value="book/translation/07-git-tools" />
+                    <option name="lastUsedInstant" value="1755687743" />
                   </RecentBranch>
                   <RecentBranch>
                     <option name="branchName" value="refactor/progit2" />
@@ -114,25 +111,25 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;book/translation/07-git-tools&quot;,
-    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/mac/Projects/WebstormProjects/Github/progit2-fa&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.keymap&quot;,
-    &quot;to.speed.mode.migration.done&quot;: &quot;true&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "git-widget-placeholder": "book/translation/08-customizing-git",
+    "junie.onboarding.icon.badge.shown": "true",
+    "last_opened_file_path": "/Users/mac/Projects/WebstormProjects/Github/progit2-fa",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "preferences.keymap",
+    "to.speed.mode.migration.done": "true",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="SharedIndexes">
     <attachedChunks>
       <set>

--- a/book/08-customizing-git/sections/attributes.asc
+++ b/book/08-customizing-git/sections/attributes.asc
@@ -1,44 +1,46 @@
-=== Git Attributes
+=== Git Attributes (ویژگی‌های گیت)
 
 (((attributes)))
-Some of these settings can also be specified for a path, so that Git applies those settings only for a subdirectory or subset of files.
-These path-specific settings are called Git attributes and are set either in a `.gitattributes` file in one of your directories (normally the root of your project) or in the `.git/info/attributes` file if you don't want the attributes file committed with your project.
 
-Using attributes, you can do things like specify separate merge strategies for individual files or directories in your project, tell Git how to diff non-text files, or have Git filter content before you check it into or out of Git.
-In this section, you'll learn about some of the attributes you can set on your paths in your Git project and see a few examples of using this feature in practice.
+برخی از این تنظیمات را می‌توان برای یک مسیر خاص نیز مشخص کرد، به طوری که گیت فقط آن تنظیمات را برای یک زیرشاخه یا زیرمجموعه‌ای از فایل‌ها اعمال کند.
+این تنظیمات خاص مسیر، ویژگی‌های گیت (Git attributes) نامیده می‌شوند و یا در فایل `.gitattributes` در یکی از دایرکتوری‌های شما (معمولاً ریشه پروژه) یا در فایل `.git/info/attributes` تنظیم می‌شوند، اگر نخواهید فایل ویژگی‌ها به همراه پروژه کامیت شود.
 
-==== Binary Files
+با استفاده از ویژگی‌ها، می‌توانید کارهایی مانند تعیین استراتژی‌های ادغام جداگانه برای فایل‌ها یا دایرکتوری‌های خاص پروژه، اطلاع دادن به گیت درباره نحوه مقایسه فایل‌های غیرمتنی، یا فیلتر کردن محتوا قبل از ثبت یا استخراج آن در گیت، انجام دهید.
+در این بخش، با برخی از ویژگی‌هایی که می‌توانید روی مسیرهای پروژه گیت خود تنظیم کنید آشنا می‌شوید و چند مثال عملی از کاربرد این قابلیت خواهید دید.
+
+==== Binary Files (فایل‌های باینری)
 
 (((binary files)))
-One cool trick for which you can use Git attributes is telling Git which files are binary (in cases it otherwise may not be able to figure out) and giving Git special instructions about how to handle those files.
-For instance, some text files may be machine generated and not diffable, whereas some binary files can be diffed.
-You'll see how to tell Git which is which.
 
-===== Identifying Binary Files
+یکی از ترفندهای جالبی که می‌توانید با ویژگی‌های گیت انجام دهید، اطلاع دادن به گیت درباره فایل‌هایی است که باینری هستند (در مواردی که گیت خودش نمی‌تواند تشخیص دهد) و دادن دستورالعمل‌های ویژه به گیت برای نحوه مدیریت این فایل‌ها.
+مثلاً برخی فایل‌های متنی ممکن است به صورت ماشینی ساخته شده باشند و قابلیت مقایسه (diff) نداشته باشند، در حالی که برخی فایل‌های باینری قابلیت مقایسه شدن دارند.
+شما خواهید آموخت چگونه به گیت بگویید کدام فایل‌ها باینری هستند و کدام نیستند.
 
-Some files look like text files but for all intents and purposes are to be treated as binary data.
-For instance, Xcode projects on macOS contain a file that ends in `.pbxproj`, which is basically a JSON (plain-text JavaScript data format) dataset written out to disk by the IDE, which records your build settings and so on.
-Although it's technically a text file (because it's all UTF-8), you don't want to treat it as such because it's really a lightweight database – you can't merge the contents if two people change it, and diffs generally aren't helpful.
-The file is meant to be consumed by a machine.
-In essence, you want to treat it like a binary file.
+===== Identifying Binary Files (شناسایی فایل‌های باینری)
 
-To tell Git to treat all `pbxproj` files as binary data, add the following line to your `.gitattributes` file:
+برخی فایل‌ها شبیه فایل متنی به نظر می‌رسند، اما باید به عنوان داده باینری با آنها رفتار شود.
+برای مثال، پروژه‌های Xcode در macOS شامل فایلی با پسوند `.pbxproj` هستند که اساساً یک مجموعه داده JSON (فرمت داده جاوااسکریپت به صورت متن ساده) است که توسط محیط توسعه (IDE) روی دیسک نوشته شده و تنظیمات ساخت و غیره را ذخیره می‌کند.
+اگرچه این فایل از نظر فنی یک فایل متنی است (چون همه‌چیزش UTF-8 است)، اما نمی‌خواهید آن را به این صورت در نظر بگیرید چون اساساً یک پایگاه داده سبک است – اگر دو نفر آن را تغییر دهند، نمی‌توانید محتوا را با هم ادغام کنید و تفاوت‌ها معمولاً مفید نیستند.
+این فایل برای استفاده ماشین طراحی شده است.
+در واقع، می‌خواهید با آن مانند یک فایل باینری رفتار کنید.
+
+برای اینکه گیت تمام فایل‌های `pbxproj.` را به عنوان داده باینری در نظر بگیرد، خط زیر را به فایل `.gitattributes` خود اضافه کنید:
 
 [source,ini]
 ----
 *.pbxproj binary
 ----
 
-Now, Git won't try to convert or fix CRLF issues; nor will it try to compute or print a diff for changes in this file when you run `git show` or `git diff` on your project.
+اکنون گیت سعی نمی‌کند این فایل‌ها را تبدیل کند یا مشکلات CRLF را اصلاح کند؛ همچنین وقتی دستور `git show` یا `git diff` را روی پروژه اجرا می‌کنید، سعی نمی‌کند تفاوت‌ها را محاسبه یا نمایش دهد.
 
-===== Diffing Binary Files
+===== Diffing Binary Files (مقایسه فایل‌های باینری)
 
-You can also use the Git attributes functionality to effectively diff binary files.
-You do this by telling Git how to convert your binary data to a text format that can be compared via the normal diff.
+شما همچنین می‌توانید از قابلیت ویژگی‌های گیت برای مقایسه مؤثر فایل‌های باینری استفاده کنید.
+این کار را با گفتن به گیت درباره چگونگی تبدیل داده‌های باینری به فرمت متنی که بتوان به روش معمول diff مقایسه کرد، انجام می‌دهید.
 
-First, you'll use this technique to solve one of the most annoying problems known to humanity: version-controlling Microsoft Word documents.
-If you want to version-control Word documents, you can stick them in a Git repository and commit every once in a while; but what good does that do?
-If you run `git diff` normally, you only see something like this:
+ابتدا، این تکنیک را برای حل یکی از مشکلات آزاردهنده بشر به کار می‌برید: کنترل نسخه اسناد مایکروسافت ورد.
+اگر می‌خواهید اسناد ورد را کنترل نسخه کنید، می‌توانید آنها را در مخزن گیت قرار داده و هر از گاهی کامیت کنید؛ اما این چه فایده‌ای دارد؟
+اگر به صورت معمولی `git diff` را اجرا کنید، فقط چیزی شبیه این می‌بینید:
 
 [source,console]
 ----
@@ -48,24 +50,24 @@ index 88839c4..4afcb7c 100644
 Binary files a/chapter1.docx and b/chapter1.docx differ
 ----
 
-You can't directly compare two versions unless you check them out and scan them manually, right?
-It turns out you can do this fairly well using Git attributes.
-Put the following line in your `.gitattributes` file:
+شما نمی‌توانید مستقیماً دو نسخه را مقایسه کنید مگر اینکه آنها را استخراج کرده و دستی بررسی کنید، درست است؟
+اما واقعیت این است که می‌توانید این کار را با استفاده از ویژگی‌های گیت به خوبی انجام دهید.
+خط زیر را در فایل `.gitattributes` خود قرار دهید:
 
 [source,ini]
 ----
 *.docx diff=word
 ----
 
-This tells Git that any file that matches this pattern (`.docx`) should use the "`word`" filter when you try to view a diff that contains changes.
-What is the "`word`" filter?
-You have to set it up.
-Here you'll configure Git to use the `docx2txt` program to convert Word documents into readable text files, which it will then diff properly.
+این به گیت می‌گوید هر فایلی که با این الگو (`.docx`) مطابقت دارد، هنگام مشاهده تفاوت‌هایی که شامل تغییرات است، باید از فیلتر "`word`" استفاده کند.
+فیلتر "`word`" چیست؟
+باید آن را تنظیم کنید.
+در اینجا گیت را پیکربندی می‌کنید تا از برنامه `docx2txt` برای تبدیل اسناد ورد به فایل‌های متنی قابل خواندن استفاده کند، سپس آن فایل‌ها را به درستی مقایسه کند.
 
-First, you'll need to install `docx2txt`; you can download it from https://sourceforge.net/projects/docx2txt[^].
-Follow the instructions in the `INSTALL` file to put it somewhere your shell can find it.
-Next, you'll write a wrapper script to convert output to the format Git expects.
-Create a file that's somewhere in your path called `docx2txt`, and add these contents:
+ابتدا باید `docx2txt` را نصب کنید؛ می‌توانید آن را از https://sourceforge.net/projects/docx2txt دانلود کنید.
+دستورالعمل‌های فایل `INSTALL` را دنبال کنید تا آن را در جایی قرار دهید که شل شما بتواند آن را پیدا کند.
+سپس، باید یک اسکریپت wrapper بنویسید تا خروجی را به فرمتی تبدیل کند که گیت انتظار دارد.
+یک فایل در مسیر PATH خود به نام `docx2txt` بسازید و این محتوا را در آن قرار دهید:
 
 [source,console]
 ----
@@ -73,20 +75,20 @@ Create a file that's somewhere in your path called `docx2txt`, and add these con
 docx2txt.pl "$1" -
 ----
 
-Don't forget to `chmod a+x` that file.
-Finally, you can configure Git to use this script:
+فراموش نکنید که به آن فایل دستور `chmod a+x` بدهید.
+در نهایت، می‌توانید گیت را پیکربندی کنید که از این اسکریپت استفاده کند:
 
 [source,console]
 ----
 $ git config diff.word.textconv docx2txt
 ----
 
-Now Git knows that if it tries to do a diff between two snapshots, and any of the files end in `.docx`, it should run those files through the "`word`" filter, which is defined as the `docx2txt` program.
-This effectively makes nice text-based versions of your Word files before attempting to diff them.
+ حال گیت می‌داند که اگر بخواهد تفاوت (diff) بین دو عکس‌برداری (snapshot) بگیرد و هر یک از فایل‌ها پسوند `.docx` داشته باشند، باید آن‌ها را از طریق فیلتر "`word`" که به برنامه `docx2txt` ارجاع داده شده است، عبور دهد.
+این کار عملاً نسخه‌های متنی خوبی از فایل‌های ورد شما ایجاد می‌کند قبل از اینکه بخواهد تفاوت آن‌ها را بگیرد.
 
-Here's an example: Chapter 1 of this book was converted to Word format and committed in a Git repository.
-Then a new paragraph was added.
-Here's what `git diff` shows:
+مثالی این‌گونه است: فصل اول این کتاب به فرمت ورد تبدیل و در مخزن گیت ثبت شده است.
+سپس پاراگراف جدیدی اضافه شده است.
+این چیزی است که `git diff` نشان می‌دهد:
 
 [source,console]
 ----
@@ -105,13 +107,13 @@ index 0b013ca..ba25db5 100644
  Many people's version-control method of choice is to copy files into another directory (perhaps a time-stamped directory, if they're clever). This approach is very common because it is so simple, but it is also incredibly error prone. It is easy to forget which directory you're in and accidentally write to the wrong file or copy over files you don't mean to.
 ----
 
-Git successfully and succinctly tells us that we added the string "`Testing: 1, 2, 3.`", which is correct.
-It's not perfect – formatting changes wouldn't show up here – but it certainly works.
+گیت با موفقیت و به‌طور خلاصه به ما می‌گوید که رشته "`Testing: 1, 2, 3.`" را اضافه کرده‌ایم که درست است.
+این کامل نیست – تغییرات قالب‌بندی اینجا نمایش داده نمی‌شوند – اما قطعاً کار می‌کند.
 
-Another interesting problem you can solve this way involves diffing image files.
-One way to do this is to run image files through a filter that extracts their EXIF information – metadata that is recorded with most image formats.
-If you download and install the `exiftool` program, you can use it to convert your images into text about the metadata, so at least the diff will show you a textual representation of any changes that happened.
-Put the following line in your `.gitattributes` file:
+مشکل جالب دیگری که می‌توانید به این روش حل کنید، گرفتن تفاوت بین فایل‌های تصویری است.
+یکی از راه‌ها این است که فایل‌های تصویری را از طریق فیلتری عبور دهید که اطلاعات EXIF آن‌ها را استخراج کند – متادیتایی که در اکثر فرمت‌های تصویری ثبت می‌شود.
+اگر برنامه `exiftool` را دانلود و نصب کنید، می‌توانید تصاویر خود را به متنی درباره متادیتا تبدیل کنید، پس حداقل تفاوت به شما نمای متنی از هر تغییر ایجاد شده را نشان می‌دهد.
+خط زیر را در فایل `.gitattributes` خود قرار دهید:
 
 [source,ini]
 ----
@@ -125,7 +127,7 @@ Configure Git to use this tool:
 $ git config diff.exif.textconv exiftool
 ----
 
-If you replace an image in your project and run `git diff`, you see something like this:
+اگر تصویری را در پروژه خود جایگزین کنید و `git diff` را اجرا کنید، چیزی شبیه به این خواهید دید:
 
 [source,diff]
 ----
@@ -149,35 +151,35 @@ index 88839c4..4afcb7c 100644
  Color Type                      : RGB with Alpha
 ----
 
-You can easily see that the file size and image dimensions have both changed.
+شما به‌راحتی می‌توانید ببینید که اندازه فایل و ابعاد تصویر هر دو تغییر کرده‌اند.
 
 [[_keyword_expansion]]
-==== Keyword Expansion
+==== Keyword Expansion (گسترش کلیدواژه)
 
 (((keyword expansion)))
-SVN- or CVS-style keyword expansion is often requested by developers used to those systems.
-The main problem with this in Git is that you can't modify a file with information about the commit after you've committed, because Git checksums the file first.
-However, you can inject text into a file when it's checked out and remove it again before it's added to a commit.
-Git attributes offers you two ways to do this.
+گسترش کلیدواژه به سبک SVN یا CVS اغلب توسط توسعه‌دهندگانی که به این سیستم‌ها عادت دارند درخواست می‌شود.
+مشکل اصلی در گیت این است که نمی‌توانید اطلاعات مربوط به کامیت را بعد از کامیت کردن فایل تغییر دهید، چون گیت ابتدا چکسام فایل را محاسبه می‌کند.
+با این حال، می‌توانید متن را هنگام بیرون کشیدن (checkout) فایل وارد کنید و قبل از اضافه کردن آن به کامیت، دوباره حذفش کنید.
+ویژگی attributes در گیت دو راه برای انجام این کار به شما می‌دهد.
 
-First, you can inject the SHA-1 checksum of a blob into an `$Id$` field in the file automatically.
-If you set this attribute on a file or set of files, then the next time you check out that branch, Git will replace that field with the SHA-1 of the blob.
-It's important to notice that it isn't the SHA-1 of the commit, but of the blob itself.
-Put the following line in your `.gitattributes` file:
+اول اینکه می‌توانید چکسام SHA-1 یک بلاک داده (blob) را به‌صورت خودکار داخل فیلد `$Id$` در فایل تزریق کنید.
+اگر این ویژگی را روی یک یا چند فایل تنظیم کنید، دفعه بعد که آن شاخه را checkout کنید، گیت این فیلد را با SHA-1 بلاک جایگزین می‌کند.
+مهم است توجه داشته باشید که این SHA-1 مربوط به کامیت نیست، بلکه مربوط به خود بلاک است.
+خط زیر را در فایل `.gitattributes` خود قرار دهید:
 
 [source,ini]
 ----
 *.txt ident
 ----
 
-Add an `$Id$` reference to a test file:
+یک `$Id$` اضافه کنید به رفرنس تست فایلتان:
 
 [source,console]
 ----
 $ echo '$Id$' > test.txt
 ----
 
-The next time you check out this file, Git injects the SHA-1 of the blob:
+دفعه بعد که این فایل را checkout کنید، گیت SHA-1 بلاک را تزریق می‌کند:
 
 [source,console]
 ----
@@ -187,13 +189,13 @@ $ cat test.txt
 $Id: 42812b7653c7b88933f8a9d6cad0ca16714b9bb3 $
 ----
 
-However, that result is of limited use.
-If you've used keyword substitution in CVS or Subversion, you can include a datestamp – the SHA-1 isn't all that helpful, because it's fairly random and you can't tell if one SHA-1 is older or newer than another just by looking at them.
+اما این نتیجه کاربرد محدودی دارد.
+اگر در CVS یا Subversion از جایگزینی کلیدواژه استفاده کرده‌اید، می‌توانید تاریخ را نیز اضافه کنید – SHA-1 چندان مفید نیست چون کاملاً تصادفی است و نمی‌توانید فقط با نگاه کردن بفهمید کدام SHA-1 قدیمی‌تر یا جدیدتر است.
 
-It turns out that you can write your own filters for doing substitutions in files on commit/checkout.
-These are called "`clean`" and "`smudge`" filters.
-In the `.gitattributes` file, you can set a filter for particular paths and then set up scripts that will process files just before they're checked out ("`smudge`", see <<filters_a>>) and just before they're staged ("`clean`", see <<filters_b>>).
-These filters can be set to do all sorts of fun things.
+مشخص شده است که می‌توانید فیلترهای خودتان را برای انجام جایگزینی‌ها روی فایل‌ها هنگام commit/checkout بنویسید.
+این‌ها به عنوان فیلترهای "`clean`" و "`smudge`" شناخته می‌شوند.
+در فایل `.gitattributes`، می‌توانید فیلتر را برای مسیرهای خاص تنظیم کنید و سپس اسکریپت‌هایی راه‌اندازی کنید که فایل‌ها را درست قبل از checkout ("`smudge`"، نگاه کنید به <<filters_a>>) و درست قبل از stage شدن ("`clean`"، نگاه کنید به <<filters_b>>) پردازش می‌کنند.
+این فیلترها می‌توانند کارهای جالب و متنوعی انجام دهند.
 
 [[filters_a]]
 .The "`smudge`" filter is run on checkout
@@ -203,15 +205,15 @@ image::images/smudge.png[The “smudge” filter is run on checkout]
 .The "`clean`" filter is run when files are staged
 image::images/clean.png[The “clean” filter is run when files are staged]
 
-The original commit message for this feature gives a simple example of running all your C source code through the `indent` program before committing.
-You can set it up by setting the filter attribute in your `.gitattributes` file to filter `\*.c` files with the "`indent`" filter:
+پیام کامیت اصلی این ویژگی، مثالی ساده از اجرای تمام کدهای منبع C شما از طریق برنامه `indent` قبل از commit را ارائه می‌دهد.
+می‌توانید این را با تنظیم ویژگی فیلتر در فایل `.gitattributes` خود برای فیلتر کردن فایل‌های `*.c` با فیلتر "`indent`" انجام دهید:
 
 [source,ini]
 ----
 *.c filter=indent
 ----
 
-Then, tell Git what the "`indent`" filter does on smudge and clean:
+سپس به گیت بگویید که فیلتر "`indent`" هنگام smudge و clean چه کاری انجام می‌دهد:
 
 [source,console]
 ----
@@ -219,13 +221,13 @@ $ git config --global filter.indent.clean indent
 $ git config --global filter.indent.smudge cat
 ----
 
-In this case, when you commit files that match `*.c`, Git will run them through the indent program before it stages them and then run them through the `cat` program before it checks them back out onto disk.
-The `cat` program does essentially nothing: it spits out the same data that it comes in.
-This combination effectively filters all C source code files through `indent` before committing.
+در این حالت، وقتی فایل‌هایی که با `*.c` مطابقت دارند را commit می‌کنید، گیت آن‌ها را قبل از stage شدن از طریق برنامه `indent` عبور می‌دهد و سپس قبل از اینکه دوباره آن‌ها را روی دیسک بیرون بکشد، از طریق برنامه `cat` عبور می‌دهد.
+برنامه `cat` عملاً کاری انجام نمی‌دهد: همان داده ورودی را بدون تغییر خروجی می‌دهد.
+این ترکیب عملاً تمام فایل‌های منبع C را قبل از commit از طریق `indent` فیلتر می‌کند.
 
-Another interesting example gets `$Date$` keyword expansion, RCS style.
-To do this properly, you need a small script that takes a filename, figures out the last commit date for this project, and inserts the date into the file.
-Here is a small Ruby script that does that:
+مثال جالب دیگر، گسترش کلیدواژه `$Date$` به سبک RCS است.
+برای انجام درست این کار، به اسکریپت کوچکی نیاز دارید که نام فایل را بگیرد، آخرین تاریخ کامیت این پروژه را پیدا کند و تاریخ را در فایل وارد کند.
+در اینجا یک اسکریپت کوچک روبی است که این کار را انجام می‌دهد:
 
 [source,ruby]
 ----
@@ -235,10 +237,10 @@ last_date = `git log --pretty=format:"%ad" -1`
 puts data.gsub('$Date$', '$Date: ' + last_date.to_s + '$')
 ----
 
-All the script does is get the latest commit date from the `git log` command, stick that into any `$Date$` strings it sees in stdin, and print the results – it should be simple to do in whatever language you're most comfortable in.
-You can name this file `expand_date` and put it in your path.
-Now, you need to set up a filter in Git (call it `dater`) and tell it to use your `expand_date` filter to smudge the files on checkout.
-You'll use a Perl expression to clean that up on commit:
+ تمام کاری که این اسکریپت انجام می‌دهد این است که جدیدترین تاریخ کامیت را از دستور `git log` می‌گیرد، آن را در هر رشته‌ای از نوع `$Date$` که در ورودی استاندارد می‌بیند جایگزین می‌کند و نتیجه را چاپ می‌کند – این کار باید به سادگی با هر زبانی که به آن مسلط هستید قابل انجام باشد.
+می‌توانید این فایل را با نام `expand_date` ذخیره کرده و در مسیر دستیابی سیستم خود قرار دهید.
+حالا باید یک فیلتر در Git تعریف کنید (مثلاً آن را `dater` بنامید) و به Git بگویید که هنگام چک‌اوت فایل‌ها از فیلتر `expand_date` برای جایگزینی استفاده کند.
+برای پاکسازی این تغییرات هنگام کامیت از یک عبارت Perl استفاده خواهید کرد:
 
 [source,console]
 ----
@@ -246,8 +248,8 @@ $ git config filter.dater.smudge expand_date
 $ git config filter.dater.clean 'perl -pe "s/\\\$Date[^\\\$]*\\\$/\\\$Date\\\$/"'
 ----
 
-This Perl snippet strips out anything it sees in a `$Date$` string, to get back to where you started.
-Now that your filter is ready, you can test it by setting up a Git attribute for that file that engages the new filter and creating a file with your `$Date$` keyword:
+این قطعه کد Perl هر چیزی را که در رشته `$Date$` می‌بیند پاک می‌کند تا به حالت اولیه برگردد.
+حال که فیلتر شما آماده است، می‌توانید آن را با تنظیم یک ویژگی Git برای آن فایل که فیلتر جدید را فعال می‌کند و ایجاد فایلی با کلیدواژه `$Date$`، آزمایش کنید:
 
 [source,ini]
 ----
@@ -259,7 +261,7 @@ date*.txt filter=dater
 $ echo '# $Date$' > date_test.txt
 ----
 
-If you commit those changes and check out the file again, you see the keyword properly substituted:
+اگر این تغییرات را کامیت کنید و دوباره فایل را چک‌اوت کنید، می‌بینید که کلیدواژه به درستی جایگزین شده است:
 
 [source,console]
 ----
@@ -271,35 +273,35 @@ $ cat date_test.txt
 # $Date: Tue Apr 21 07:26:52 2009 -0700$
 ----
 
-You can see how powerful this technique can be for customized applications.
-You have to be careful, though, because the `.gitattributes` file is committed and passed around with the project, but the driver (in this case, `dater`) isn't, so it won't work everywhere.
-When you design these filters, they should be able to fail gracefully and have the project still work properly.
+می‌توانید ببینید این روش چقدر می‌تواند در برنامه‌های سفارشی قدرتمند باشد.
+اما باید مراقب باشید، چون فایل `.gitattributes` همراه پروژه کامیت و منتقل می‌شود، اما درایور (در اینجا `dater`) اینطور نیست، بنابراین در همه جا کار نخواهد کرد.
+وقتی این فیلترها را طراحی می‌کنید، باید طوری باشند که در صورت شکست، به آرامی عمل کنند و پروژه همچنان به درستی کار کند.
 
-==== Exporting Your Repository
+==== Exporting Your Repository (خروجی گرفتن از مخزن شما)
 
 (((archiving)))
-Git attribute data also allows you to do some interesting things when exporting an archive of your project.
+داده‌های ویژگی Git همچنین به شما امکان می‌دهد هنگام استخراج آرشیو پروژه خود، کارهای جالبی انجام دهید.
 
 ===== `export-ignore`
 
-You can tell Git not to export certain files or directories when generating an archive.
-If there is a subdirectory or file that you don't want to include in your archive file but that you do want checked into your project, you can determine those files via the `export-ignore` attribute.
+شما می‌توانید به گیت بگویید که هنگام ساخت آرشیو، برخی فایل‌ها یا پوشه‌ها را صادر نکند.
+اگر زیرپوشه یا فایلی وجود دارد که نمی‌خواهید در فایل آرشیو قرار بگیرد ولی می‌خواهید در پروژه‌تان ثبت شود، می‌توانید این فایل‌ها را با استفاده از صفت `export-ignore` مشخص کنید.
 
-For example, say you have some test files in a `test/` subdirectory, and it doesn't make sense to include them in the tarball export of your project.
-You can add the following line to your Git attributes file:
+برای مثال، فرض کنید چند فایل تست در زیرپوشه‌ای به نام `test/` دارید و منطقی نیست که آن‌ها را در خروجی tarball پروژه‌تان وارد کنید.
+می‌توانید خط زیر را به فایل ویژگی‌های گیت خود (Git attributes file) اضافه کنید:
 
 [source,ini]
 ----
 test/ export-ignore
 ----
 
-Now, when you run `git archive` to create a tarball of your project, that directory won't be included in the archive.
+حالا وقتی دستور `git archive` را برای ساخت tarball پروژه اجرا کنید، آن پوشه در آرشیو قرار نخواهد گرفت.
 
 ===== `export-subst`
 
-When exporting files for deployment you can apply ``git log```'s formatting and keyword-expansion processing to selected portions of files marked with the ``export-subst`` attribute.
+وقتی فایل‌ها را برای استقرار (deployment) صادر می‌کنید، می‌توانید قالب‌بندی و جایگزینی کلمات کلیدی (keyword-expansion) دستور `git log` را روی بخش‌های انتخاب‌شده‌ای از فایل‌ها که با صفت `export-subst` علامت‌گذاری شده‌اند، اعمال کنید.
 
-For instance, if you want to include a file named `LAST_COMMIT` in your project, and have metadata about the last commit automatically injected into it when `git archive` runs, you can for example set up your `.gitattributes` and `LAST_COMMIT` files like this:
+برای مثال، اگر می‌خواهید فایلی به نام `LAST_COMMIT` در پروژه خود داشته باشید و اطلاعات متادیتای آخرین کامیت به‌صورت خودکار هنگام اجرای `git archive` در آن درج شود، می‌توانید فایل‌های `.gitattributes` و `LAST_COMMIT` خود را به این صورت تنظیم کنید:
 
 [source,ini]
 ----
@@ -313,7 +315,7 @@ $ git add LAST_COMMIT .gitattributes
 $ git commit -am 'adding LAST_COMMIT file for archives'
 ----
 
-When you run `git archive`, the contents of the archived file will look like this:
+وقتی دستور `git archive` را اجرا کنید، محتوای فایل آرشیو شده به این صورت خواهد بود:
 
 [source,console]
 ----
@@ -322,7 +324,7 @@ $ cat ../deployment-testing/LAST_COMMIT
 Last commit date: Tue Apr 21 08:38:48 2009 -0700 by Scott Chacon
 ----
 
-The substitutions can include for example the commit message and any `git notes`, and `git log` can do simple word wrapping:
+جایگزینی‌ها می‌توانند شامل پیام کامیت و هر گونه `git notes` باشند، و دستور `git log` می‌تواند به صورت ساده متن را به خط بعدی منتقل کند.
 
 [source,console]
 ----
@@ -341,31 +343,31 @@ Last commit: 312ccc8 by Jim Hill at Fri May 8 09:14:04 2015 -0700
          strips the surrounding `$Format:` and `$` markup from the output.
 ----
 
-The resulting archive is suitable for deployment work, but like any exported archive it isn't suitable for further development work.
+آرشیو حاصل برای کارهای استقرار مناسب است، اما مانند هر آرشیو صادر شده‌ای برای توسعه‌های بعدی مناسب نیست.
 
-==== Merge Strategies
+==== Merge Strategies (استراتژی‌های ادغام)
 
 (((merging, strategies)))
-You can also use Git attributes to tell Git to use different merge strategies for specific files in your project.
-One very useful option is to tell Git to not try to merge specific files when they have conflicts, but rather to use your side of the merge over someone else's.
+شما همچنین می‌توانید از ویژگی‌های Git استفاده کنید تا به Git بگویید برای فایل‌های خاص در پروژه‌تان از استراتژی‌های ادغام متفاوتی استفاده کند.
+یک گزینه بسیار مفید این است که به Git بگویید وقتی فایل‌های خاصی دارای تعارض هستند، تلاش نکند آن‌ها را ادغام کند، بلکه نسخه شما را در ادغام بر نسخه دیگران ارجح بداند.
 
-This is helpful if a branch in your project has diverged or is specialized, but you want to be able to merge changes back in from it, and you want to ignore certain files.
-Say you have a database settings file called `database.xml` that is different in two branches, and you want to merge in your other branch without messing up the database file.
-You can set up an attribute like this:
+این کار زمانی مفید است که یک شاخه در پروژه شما جدا شده یا تخصصی شده باشد، اما شما بخواهید تغییرات آن شاخه را مجدداً ادغام کنید و بخواهید برخی فایل‌ها را نادیده بگیرید.
+فرض کنید یک فایل تنظیمات پایگاه داده به نام `database.xml` در دو شاخه متفاوت است و شما می‌خواهید شاخه دیگر را ادغام کنید بدون اینکه فایل پایگاه داده دچار مشکل شود.
+می‌توانید یک ویژگی به این شکل تنظیم کنید:
 
 [source,ini]
 ----
 database.xml merge=ours
 ----
 
-And then define a dummy `ours` merge strategy with:
+سپس یک استراتژی ادغام ساختگی به نام `ours` تعریف کنید:
 
 [source,console]
 ----
 $ git config --global merge.ours.driver true
 ----
 
-If you merge in the other branch, instead of having merge conflicts with the `database.xml` file, you see something like this:
+اگر شاخه دیگر را ادغام کنید، به جای اینکه با فایل `database.xml` تعارض ادغام داشته باشید، چیزی شبیه به این مشاهده خواهید کرد:
 
 [source,console]
 ----
@@ -374,4 +376,4 @@ Auto-merging database.xml
 Merge made by recursive.
 ----
 
-In this case, `database.xml` stays at whatever version you originally had.
+در این حالت، فایل `database.xml` به همان نسخه‌ای که در ابتدا داشتید باقی می‌ماند.

--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -1,9 +1,9 @@
 [[_git_config]]
-=== Git Configuration
+=== Git Configuration (پیکربندی گیت)
 
 (((git commands, config)))
-As you read briefly in <<ch01-getting-started#ch01-getting-started>>, you can specify Git configuration settings with the `git config` command.
-One of the first things you did was set up your name and email address:
+همان‌طور که به‌طور خلاصه در <<ch01-getting-started#ch01-getting-started>> خواندید، می‌توانید تنظیمات پیکربندی گیت را با دستور `git config` مشخص کنید.
+یکی از اولین کارهایی که انجام دادید، تنظیم نام و آدرس ایمیل‌تان بود:
 
 [source,console]
 ----
@@ -11,20 +11,20 @@ $ git config --global user.name "John Doe"
 $ git config --global user.email johndoe@example.com
 ----
 
-Now you'll learn a few of the more interesting options that you can set in this manner to customize your Git usage.
+اکنون چند گزینه جالب‌تر را خواهید آموخت که می‌توانید به این روش تنظیم کنید تا استفاده از گیت را شخصی‌سازی کنید.
 
-First, a quick review: Git uses a series of configuration files to determine non-default behavior that you may want.
-The first place Git looks for these values is in the system-wide `[path]/etc/gitconfig` file, which contains settings that are applied to every user on the system and all of their repositories.
-If you pass the option `--system` to `git config`, it reads and writes from this file specifically.
+ابتدا یک مرور سریع: گیت از مجموعه‌ای فایل پیکربندی برای تعیین رفتار غیرپیش‌فرض که ممکن است بخواهید، استفاده می‌کند.
+اولین جایی که گیت به دنبال این مقادیر می‌گردد، فایل سیستمی `[path]/etc/gitconfig` است که شامل تنظیماتی است که برای همه کاربران سیستم و تمام مخازن آن‌ها اعمال می‌شود.
+اگر گزینه `--system` را به دستور `git config` بدهید، به‌طور خاص این فایل را می‌خواند و می‌نویسد.
 
-The next place Git looks is the `~/.gitconfig` (or `~/.config/git/config`) file, which is specific to each user.
-You can make Git read and write to this file by passing the `--global` option.
+گام بعدی، فایل `~/.gitconfig` (یا `~/.config/git/config`) است که مخصوص هر کاربر است.
+می‌توانید با دادن گزینه `--global` به گیت بگویید این فایل را بخواند و بنویسد.
 
-Finally, Git looks for configuration values in the configuration file in the Git directory (`.git/config`) of whatever repository you're currently using.
-These values are specific to that single repository, and represent passing the `--local` option to `git config`.
-If you don't specify which level you want to work with, this is the default.
+در نهایت، گیت به دنبال مقادیر پیکربندی در فایل پیکربندی موجود در پوشه گیت (`.git/config`) مخزنی که در حال حاضر استفاده می‌کنید می‌گردد.
+این مقادیر مختص همان مخزن خاص هستند و معادل دادن گزینه `--local` به دستور `git config` است.
+اگر مشخص نکنید که کدام سطح را می‌خواهید تنظیم کنید، این سطح به‌طور پیش‌فرض انتخاب می‌شود.
 
-Each of these "`levels`" (system, global, local) overwrites values in the previous level, so values in `.git/config` trump those in `[path]/etc/gitconfig`, for instance.
+هر یک از این «سطوح» (سیستمی، سراسری، محلی) مقادیر سطوح قبلی را بازنویسی می‌کنند، به‌طوری‌که مقادیر موجود در `.git/config` بر مقادیر `[path]/etc/gitconfig` اولویت دارند.
 
 [NOTE]
 ====
@@ -55,23 +55,23 @@ For advanced use cases you may want to look up "Conditional includes" in the doc
 ===== `core.editor`
 
 ((($EDITOR)))((($VISUAL, see $EDITOR)))
-By default, Git uses whatever you've set as your default text editor via one of the shell environment variables `VISUAL` or `EDITOR`, or else falls back to the `vi` editor to create and edit your commit and tag messages.
-To change that default to something else, you can use the `core.editor` setting:
+به طور پیش‌فرض، گیت از ویرایشگری که به عنوان ویرایشگر متنی پیش‌فرض خود از طریق یکی از متغیرهای محیطی شل `VISUAL` یا `EDITOR` تنظیم کرده‌اید استفاده می‌کند، و در غیر این صورت به ویرایشگر `vi` بازمی‌گردد تا پیام‌های کامیت و تگ شما را ایجاد و ویرایش کند.
+برای تغییر این پیش‌فرض به گزینه‌ای دیگر، می‌توانید از تنظیم `core.editor` استفاده کنید:
 
 [source,console]
 ----
 $ git config --global core.editor emacs
 ----
 
-Now, no matter what is set as your default shell editor, Git will fire up Emacs to edit messages.
+اکنون، صرف‌نظر از اینکه ویرایشگر پیش‌فرض شل شما چه باشد، گیت برای ویرایش پیام‌ها Emacs را اجرا خواهد کرد.
 
 ===== `commit.template`
 
 (((commit templates)))
-If you set this to the path of a file on your system, Git will use that file as the default initial message when you commit.
-The value in creating a custom commit template is that you can use it to remind yourself (or others) of the proper format and style when creating a commit message.
+اگر این مقدار را به مسیر یک فایل در سیستم خود تنظیم کنید، گیت آن فایل را به عنوان پیام اولیه پیش‌فرض هنگام کامیت استفاده خواهد کرد.
+ارزش ایجاد یک قالب کامیت سفارشی در این است که می‌توانید از آن برای یادآوری به خودتان (یا دیگران) درباره قالب و سبک مناسب هنگام ایجاد پیام کامیت استفاده کنید.
 
-For instance, consider a template file at `~/.gitmessage.txt` that looks like this:
+برای مثال، فرض کنید یک فایل قالب در مسیر `~/.gitmessage.txt` دارید که به این صورت است:
 
 [source,text]
 ----
@@ -83,9 +83,9 @@ feel free to be detailed.
 [Ticket: X]
 ----
 
-Note how this commit template reminds the committer to keep the subject line short (for the sake of `git log --oneline` output), to add further detail under that, and to refer to an issue or bug tracker ticket number if one exists.
+توجه کنید چگونه این قالب کامیت به کامیت‌کننده یادآوری می‌کند که خط موضوع را کوتاه نگه دارد (برای خروجی `git log --oneline`)، جزئیات بیشتری را در زیر آن اضافه کند، و در صورت وجود، به شماره تیکت مسئله یا باگ ردیاب اشاره نماید.
 
-To tell Git to use it as the default message that appears in your editor when you run `git commit`, set the `commit.template` configuration value:
+برای اینکه به گیت بگویید این فایل را به عنوان پیام پیش‌فرضی که هنگام اجرای `git commit` در ویرایشگر ظاهر می‌شود استفاده کند، مقدار پیکربندی `commit.template` را تنظیم کنید:
 
 [source,console]
 ----
@@ -93,7 +93,7 @@ $ git config --global commit.template ~/.gitmessage.txt
 $ git commit
 ----
 
-Then, your editor will open to something like this for your placeholder commit message when you commit:
+سپس ویرایشگر شما باز می‌شود و چیزی شبیه به این برای پیام تعهد موقت شما هنگام انجام commit نمایش داده می‌شود:
 
 [source,text]
 ----
@@ -116,33 +116,31 @@ feel free to be detailed.
 ".git/COMMIT_EDITMSG" 14L, 297C
 ----
 
-If your team has a commit-message policy, then putting a template for that policy on your system and configuring Git to use it by default can help increase the chance of that policy being followed regularly.
+اگر تیم شما سیاست مشخصی برای پیام‌های commit دارد، قرار دادن یک قالب برای آن سیاست در سیستم خود و تنظیم Git برای استفاده پیش‌فرض از آن، می‌تواند شانس پیروی منظم از آن سیاست را افزایش دهد.
 
 ===== `core.pager`
 
 (((pager)))
-This setting determines which pager is used when Git pages output such as `log` and `diff`.
-You can set it to `more` or to your favorite pager (by default, it's `less`), or you can turn it off by setting it to a blank string:
+این تنظیم تعیین می‌کند که هنگام نمایش خروجی‌هایی مانند `log` و `diff`، از کدام صفحه‌بند (pager) استفاده شود. می‌توانید آن را روی `more` یا صفحه‌بند مورد علاقه خود تنظیم کنید (به طور پیش‌فرض `less` است)، یا با تنظیم آن روی رشته خالی، آن را غیرفعال کنید:
 
 [source,console]
 ----
 $ git config --global core.pager ''
 ----
 
-If you run that, Git will print the entire output of all commands, no matter how long they are.
+اگر این دستور را اجرا کنید، Git تمام خروجی تمام دستورات را چاپ می‌کند، بدون توجه به طول آن‌ها.
 
 ===== `user.signingkey`
 
 (((GPG)))
-If you're making signed annotated tags (as discussed in <<ch07-git-tools#_signing>>), setting your GPG signing key as a configuration setting makes things easier.
-Set your key ID like so:
+اگر در حال ساختن تگ‌های Annotated امضا شده هستید (همانطور که در <<ch07-git-tools#_signing>> بحث شده)، تنظیم کلید امضای GPG خود به عنوان یک تنظیمات پیکربندی کار را آسان‌تر می‌کند. شناسه کلید خود را به این شکل تنظیم کنید:
 
 [source,console]
 ----
 $ git config --global user.signingkey <gpg-key-id>
 ----
 
-Now, you can sign tags without having to specify your key every time with the `git tag` command:
+حال می‌توانید بدون اینکه هر بار در دستور `git tag` کلید خود را مشخص کنید، تگ‌ها را امضا کنید:
 
 [source,console]
 ----
@@ -152,14 +150,11 @@ $ git tag -s <tag-name>
 ===== `core.excludesfile`
 
 (((excludes)))(((.gitignore)))
-You can put patterns in your project's `.gitignore` file to have Git not see them as untracked files or try to stage them when you run `git add` on them, as discussed in <<ch02-git-basics-chapter#_ignoring>>.
+می‌توانید الگوهایی را در فایل `.gitignore` پروژه خود قرار دهید تا Git آن‌ها را به عنوان فایل‌های ردیابی‌نشده نبیند یا هنگام اجرای `git add` آن‌ها را برای مرحله‌بندی در نظر نگیرد، همانطور که در <<ch02-git-basics-chapter#_ignoring>> توضیح داده شده.
 
-But sometimes you want to ignore certain files for all repositories that you work with.
-If your computer is running macOS, you're probably familiar with `.DS_Store` files.
-If your preferred editor is Emacs or Vim, you know about filenames that end with a `~` or `.swp`.
+اما گاهی می‌خواهید بعضی فایل‌ها را برای همه مخازنی که با آن‌ها کار می‌کنید نادیده بگیرید. اگر سیستم شما macOS است، احتمالا با فایل‌های `.DS_Store` آشنا هستید. اگر ویرایشگر مورد علاقه شما Emacs یا Vim است، با فایل‌هایی که با `~` یا `.swp` پایان می‌یابند آشنایید.
 
-This setting lets you write a kind of global `.gitignore` file.
-If you create a `~/.gitignore_global` file with these contents:
+این تنظیم به شما امکان می‌دهد یک نوع فایل `.gitignore` سراسری بنویسید. اگر یک فایل `~/.gitignore_global` با این محتویات ایجاد کنید:
 
 [source,ini]
 ----
@@ -168,12 +163,12 @@ If you create a `~/.gitignore_global` file with these contents:
 .DS_Store
 ----
 
-…and you run `git config --global core.excludesfile ~/.gitignore_global`, Git will never again bother you about those files.
+…و دستور `git config --global core.excludesfile ~/.gitignore_global` را اجرا کنید، Git دیگر هرگز شما را درباره این فایل‌ها اذیت نخواهد کرد.
 
 ===== `help.autocorrect`
 
 (((autocorrect)))
-If you mistype a command, it shows you something like this:
+اگر دستوری را اشتباه تایپ کنید، چیزی شبیه به این به شما نمایش داده می‌شود:
 
 [source,console]
 ----
@@ -184,8 +179,8 @@ The most similar command is
     checkout
 ----
 
-Git helpfully tries to figure out what you meant, but it still refuses to do it.
-If you set `help.autocorrect` to 1, Git will actually run this command for you:
+گیت به طور مفید سعی می‌کند بفهمد منظورتان چه بوده است، اما همچنان از انجام آن خودداری می‌کند.
+اگر `help.autocorrect` را روی ۱ تنظیم کنید، گیت در واقع این دستور را برای شما اجرا خواهد کرد:
 
 [source,console]
 ----
@@ -195,68 +190,68 @@ Continuing under the assumption that you meant 'checkout'
 in 0.1 seconds automatically...
 ----
 
-Note that "`0.1 seconds`" business.
-`help.autocorrect` is actually an integer which represents tenths of a second.
-So if you set it to 50, Git will give you 5 seconds to change your mind before executing the autocorrected command.
+به آن "۰.۱ ثانیه" توجه کنید.
+`help.autocorrect` در واقع یک عدد صحیح است که دهم ثانیه را نشان می‌دهد.
+بنابراین اگر آن را روی ۵۰ تنظیم کنید، گیت به شما ۵ ثانیه فرصت می‌دهد تا قبل از اجرای دستور تصحیح‌شده خودکار، نظر خود را تغییر دهید.
 
-==== Colors in Git
+==== Colors in Git (رنگ ها در گیت)
 
 (((color)))
-Git fully supports colored terminal output, which greatly aids in visually parsing command output quickly and easily.
-A number of options can help you set the coloring to your preference.
+گیت به طور کامل از خروجی رنگی ترمینال پشتیبانی می‌کند که به سرعت و به راحتی به تجزیه بصری خروجی دستورات کمک شایانی می‌کند.
+تعدادی گزینه می‌توانند به شما در تنظیم رنگ‌بندی بر اساس ترجیحاتتان کمک کنند.
 
 ===== `color.ui`
 
-Git automatically colors most of its output, but there's a master switch if you don't like this behavior.
-To turn off all Git's colored terminal output, do this:
+گیت به طور خودکار بیشتر خروجی خود را رنگی می‌کند، اما اگر این رفتار را دوست ندارید، یک کلید اصلی وجود دارد.
+برای خاموش کردن تمام خروجی‌های رنگی ترمینال گیت، این کار را انجام دهید:
 
 [source,console]
 ----
 $ git config --global color.ui false
 ----
 
-The default setting is `auto`, which colors output when it's going straight to a terminal, but omits the color-control codes when the output is redirected to a pipe or a file.
+تنظیم پیش‌فرض `auto` است که خروجی را وقتی مستقیماً به ترمینال می‌رود رنگی می‌کند، اما کدهای کنترل رنگ را وقتی خروجی به لوله یا فایل هدایت می‌شود، حذف می‌کند.
 
-You can also set it to `always` to ignore the difference between terminals and pipes.
-You'll rarely want this; in most scenarios, if you want color codes in your redirected output, you can instead pass a `--color` flag to the Git command to force it to use color codes.
-The default setting is almost always what you'll want.
+همچنین می‌توانید آن را روی `always` تنظیم کنید تا تفاوت بین ترمینال‌ها و لوله‌ها نادیده گرفته شود.
+شما به ندرت این را می‌خواهید؛ در بیشتر سناریوها، اگر کدهای رنگی در خروجی هدایت‌شده خود می‌خواهید، می‌توانید به جای آن پرچم `--color` را به دستور گیت پاس دهید تا آن را مجبور به استفاده از کدهای رنگی کند.
+تنظیمات پیش‌فرض تقریباً همیشه همان چیزی است که می‌خواهید.
 
 ===== `color.*`
 
-If you want to be more specific about which commands are colored and how, Git provides verb-specific coloring settings.
-Each of these can be set to `true`, `false`, or `always`:
+اگر می‌خواهید در مورد اینکه کدام دستورات رنگی هستند و چگونه، دقیق‌تر باشید، گیت تنظیمات رنگ‌آمیزی خاص فعل را ارائه می‌دهد.
+هر یک از این موارد را می‌توان روی `true`، `false` یا `always` تنظیم کرد:
 
   color.branch
   color.diff
   color.interactive
   color.status
 
-In addition, each of these has subsettings you can use to set specific colors for parts of the output, if you want to override each color.
-For example, to set the meta information in your diff output to blue foreground, black background, and bold text, you can run:
+علاوه بر این، هر یک از اینها دارای زیرمجموعه‌هایی هستند که می‌توانید از آنها برای تنظیم رنگ‌های خاص برای بخش‌هایی از خروجی استفاده کنید، اگر می‌خواهید هر رنگ را بازنویسی کنید.
+به عنوان مثال، برای تنظیم اطلاعات متا در خروجی diff خود به رنگ آبی پیش‌زمینه، مشکی پس‌زمینه و متن پررنگ، می‌توانید دستور زیر را اجرا کنید:
 
 [source,console]
 ----
 $ git config --global color.diff.meta "blue black bold"
 ----
 
-You can set the color to any of the following values: `normal`, `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, or `white`.
-If you want an attribute like bold in the previous example, you can choose from `bold`, `dim`, `ul` (underline), `blink`, and `reverse` (swap foreground and background).
+می‌توانید رنگ را روی هر یک از مقادیر زیر تنظیم کنید: `عادی`، `سیاه`، `قرمز`، `سبز`، `زرد`، `آبی`، `سرخابی`، `فیروزه‌ای` یا `سفید`.
+اگر می‌خواهید ویژگی‌ای مانند پررنگ در مثال قبلی داشته باشید، می‌توانید از بین `bold` (پررنگ)، `dim` (کم‌نور)، `ul` (زیرخط)، `blink` (چشمک زدن) و `reverse` (جابجایی پیش‌زمینه و پس‌زمینه) انتخاب کنید.
 
 [[_external_merge_tools]]
 ==== External Merge and Diff Tools
 
 (((mergetool)))(((difftool)))
-Although Git has an internal implementation of diff, which is what we've been showing in this book, you can set up an external tool instead.
-You can also set up a graphical merge-conflict-resolution tool instead of having to resolve conflicts manually.
-We'll demonstrate setting up the Perforce Visual Merge Tool (P4Merge) to do your diffs and merge resolutions, because it's a nice graphical tool and it's free.
+اگرچه گیت پیاده‌سازی داخلی برای diff دارد که همان چیزی است که ما در این کتاب نشان داده‌ایم، اما می‌توانید به جای آن یک ابزار خارجی را راه‌اندازی کنید.
+همچنین می‌توانید به جای حل دستی تعارضات، یک ابزار حل تعارض ادغام گرافیکی را راه‌اندازی کنید.
+ما نحوه راه‌اندازی ابزار تجمیع بصری پرفورس (P4Merge) را برای انجام تفاوت‌ها و حل تجمیع‌های شما نشان خواهیم داد، زیرا این یک ابزار گرافیکی خوب و رایگان است.
 
-If you want to try this out, P4Merge works on all major platforms, so you should be able to do so.
-We'll use path names in the examples that work on macOS and Linux systems; for Windows, you'll have to change `/usr/local/bin` to an executable path in your environment.
+اگر می‌خواهید این را امتحان کنید، P4Merge روی تمام پلتفرم‌های اصلی کار می‌کند، بنابراین باید بتوانید این کار را انجام دهید.
+در مثال‌هایی که روی سیستم‌های macOS و لینوکس کار می‌کنند، از نام مسیرها استفاده خواهیم کرد؛ برای ویندوز، باید `/usr/local/bin` را به مسیر اجرایی در محیط خود تغییر دهید.
 
-To begin, https://www.perforce.com/products/helix-core-apps/merge-diff-tool-p4merge[download P4Merge from Perforce^].
-Next, you'll set up external wrapper scripts to run your commands.
-We'll use the macOS path for the executable; in other systems, it will be where your `p4merge` binary is installed.
-Set up a merge wrapper script named `extMerge` that calls your binary with all the arguments provided:
+برای شروع, https://www.perforce.com/products/helix-core-apps/merge-diff-tool-p4merge[download P4Merge from Perforce^].
+بعداً، اسکریپت‌های پوشش خارجی را برای اجرای دستورات خود راه‌اندازی خواهید کرد.
+ما از مسیر macOS برای فایل اجرایی استفاده خواهیم کرد؛ در سیستم‌های دیگر، این مسیر جایی خواهد بود که باینری `p4merge` شما نصب شده است.
+یک اسکریپت پوشش ادغام به نام `extMerge` ایجاد کنید که با تمام آرگومان‌های ارائه شده باینری شما را فراخوانی می‌کند:
 
 [source,console]
 ----
@@ -265,15 +260,15 @@ $ cat /usr/local/bin/extMerge
 /Applications/p4merge.app/Contents/MacOS/p4merge $*
 ----
 
-The diff wrapper checks to make sure seven arguments are provided and passes two of them to your merge script.
-By default, Git passes the following arguments to the diff program:
+ روکش diff بررسی می‌کند که هفت آرگومان فراهم شده باشند و دو تا از آن‌ها را به اسکریپت merge شما منتقل می‌کند.
+به طور پیش‌فرض، گیت آرگومان‌های زیر را به برنامه diff منتقل می‌کند:
 
 [source]
 ----
 path old-file old-hex old-mode new-file new-hex new-mode
 ----
 
-Because you only want the `old-file` and `new-file` arguments, you use the wrapper script to pass the ones you need.
+چون شما فقط آرگومان‌های old-file و new-file را می‌خواهید، از اسکریپت روکش استفاده می‌کنید تا فقط آرگومان‌های مورد نیاز را منتقل کند.
 
 [source,console]
 ----
@@ -282,7 +277,7 @@ $ cat /usr/local/bin/extDiff
 [ $# -eq 7 ] && /usr/local/bin/extMerge "$2" "$5"
 ----
 
-You also need to make sure these tools are executable:
+همچنین باید مطمئن شوید این ابزارها قابل اجرا (executable) هستند:
 
 [source,console]
 ----
@@ -290,9 +285,9 @@ $ sudo chmod +x /usr/local/bin/extMerge
 $ sudo chmod +x /usr/local/bin/extDiff
 ----
 
-Now you can set up your config file to use your custom merge resolution and diff tools.
-This takes a number of custom settings: `merge.tool` to tell Git what strategy to use, `mergetool.<tool>.cmd` to specify how to run the command, `mergetool.<tool>.trustExitCode` to tell Git if the exit code of that program indicates a successful merge resolution or not, and `diff.external` to tell Git what command to run for diffs.
-So, you can either run four config commands:
+حالا می‌توانید فایل پیکربندی خود را طوری تنظیم کنید که از ابزارهای اختصاصی حل تداخلات merge و نمایش diff شما استفاده کند.
+این کار به چند تنظیم اختصاصی نیاز دارد: `merge.tool` برای گفتن به گیت که از چه استراتژی‌ای استفاده کند، `mergetool.<tool>.cmd` برای مشخص کردن چگونگی اجرای فرمان، `mergetool.<tool>.trustExitCode` برای اطلاع به گیت که آیا کد خروج آن برنامه نشان‌دهنده حل موفقیت‌آمیز `merge` است یا خیر، و `diff.external` برای معرفی فرمانی که برای عملیات `diff` اجرا شود.
+بنابراین، شما می‌توانید چهار فرمان تنظیمات را اجرا کنید:
 
 [source,console]
 ----
@@ -303,7 +298,7 @@ $ git config --global mergetool.extMerge.trustExitCode false
 $ git config --global diff.external extDiff
 ----
 
-or you can edit your `~/.gitconfig` file to add these lines:
+یا می‌توانید فایل `~/.gitconfig` خود را ویرایش کنید و این خطوط را اضافه کنید:
 
 [source,ini]
 ----
@@ -316,22 +311,22 @@ or you can edit your `~/.gitconfig` file to add these lines:
   external = extDiff
 ----
 
-After all this is set, if you run diff commands such as this:
+بعد از انجام همه این تنظیمات، اگر فرمان‌های diff مانند این را اجرا کنید:
 
 [source,console]
 ----
 $ git diff 32d1776b1^ 32d1776b1
 ----
 
-Instead of getting the diff output on the command line, Git fires up P4Merge, which looks something like this:
+به جای نمایش خروجی diff در خط فرمان، گیت `P4Merge` را اجرا می‌کند که چیزی شبیه به این خواهد بود:
 
 .P4Merge
 image::images/p4merge.png[P4Merge]
 
-If you try to merge two branches and subsequently have merge conflicts, you can run the command `git mergetool`; it starts P4Merge to let you resolve the conflicts through that GUI tool.
+اگر تلاش کنید دو شاخه را `merge` کنید و بعداً با تعارضات `merge` مواجه شوید، می‌توانید فرمان `git mergetool` را اجرا کنید؛ این فرمان `P4Merge` را راه‌اندازی می‌کند تا از طریق آن واسط گرافیکی تعارضات را حل کنید.
 
-The nice thing about this wrapper setup is that you can change your diff and merge tools easily.
-For example, to change your `extDiff` and `extMerge` tools to run the KDiff3 tool instead, all you have to do is edit your `extMerge` file:
+نکتهٔ خوب این راه‌حلِ روکشی این است که می‌توانید به راحتی ابزارهای diff و merge خود را تغییر دهید.
+برای مثال، برای تغییر ابزارهای `extDiff` و `extMerge` به `KDiff3`، کافی است فایل `extMerge` خود را ویرایش کنید:
 
 [source,console]
 ----
@@ -340,10 +335,10 @@ $ cat /usr/local/bin/extMerge
 /Applications/kdiff3.app/Contents/MacOS/kdiff3 $*
 ----
 
-Now, Git will use the KDiff3 tool for diff viewing and merge conflict resolution.
+حالا گیت از ابزار `KDiff3` برای نمایش `diff` و حل تعارضات `merge` استفاده خواهد کرد.
 
-Git comes preset to use a number of other merge-resolution tools without your having to set up the cmd configuration.
-To see a list of the tools it supports, try this:
+گیت به صورت پیش‌فرض برای استفاده از چندین ابزار حل تعارض دیگر نیز پیکربندی شده است بدون آنکه لازم باشد شما `cmd` را تنظیم کنید.
+برای دیدن فهرست ابزارهایی که پشتیبانی می‌کند، این را اجرا کنید:
 
 [source,console]
 ----
@@ -375,49 +370,49 @@ Some of the tools listed above only work in a windowed
 environment. If run in a terminal-only session, they will fail.
 ----
 
-If you're not interested in using KDiff3 for diff but rather want to use it just for merge resolution, and the kdiff3 command is in your path, then you can run:
+اگر تمایلی به استفاده از `KDiff3` برای نمایش `diff` ندارید اما می‌خواهید صرفاً برای حل تعارضات `merge` از آن استفاده کنید، و دستور `kdiff3` در مسیر `(PATH)` شما قرار دارد، می‌توانید این دستور را اجرا کنید:
 
 [source,console]
 ----
 $ git config --global merge.tool kdiff3
 ----
 
-If you run this instead of setting up the `extMerge` and `extDiff` files, Git will use KDiff3 for merge resolution and the normal Git diff tool for diffs.
+اگر این را اجرا کنید و به‌جای ایجاد فایل‌های `extMerge` و `extDiff`، گیت از KDiff3 برای حل تداخل‌ها و از ابزار معمولی diff گیت برای مقایسه‌ها استفاده خواهد کرد.
 
-==== Formatting and Whitespace
+==== Formatting and Whitespace (قالب‌بندی و وایت اسپیس)
 
 (((whitespace)))
-Formatting and whitespace issues are some of the more frustrating and subtle problems that many developers encounter when collaborating, especially cross-platform.
-It's very easy for patches or other collaborated work to introduce subtle whitespace changes because editors silently introduce them, and if your files ever touch a Windows system, their line endings might be replaced.
-Git has a few configuration options to help with these issues.
+مسائل مربوط به قالب‌بندی و فاصله‌های سفید از جمله مشکلات خسته‌کننده و ظریفی هستند که بسیاری از توسعه‌دهندگان هنگام همکاری، به‌ویژه در محیط‌های چندسکویی، با آن‌ها مواجه می‌شوند.
+خیلی آسان است که پَچ‌ها یا دیگر کارهای مشترک تغییرات ظریف در فاصله‌های سفید ایجاد کنند، زیرا ویرایشگرها این تغییرات را به‌صورت پنهانی اعمال می‌کنند، و اگر فایل‌های شما به سیستمی با ویندوز برسند ممکن است پایان خط‌ها (line endings) جایگزین شوند.
+گیت چند گزینهٔ پیکربندی برای کمک به این مسائل دارد.
 
 ===== `core.autocrlf`
 
 (((crlf)))(((line endings)))
-If you're programming on Windows and working with people who are not (or vice-versa), you'll probably run into line-ending issues at some point.
-This is because Windows uses both a carriage-return character and a linefeed character for newlines in its files, whereas macOS and Linux systems use only the linefeed character.
-This is a subtle but incredibly annoying fact of cross-platform work; many editors on Windows silently replace existing LF-style line endings with CRLF, or insert both line-ending characters when the user hits the enter key.
+اگر روی ویندوز برنامه‌نویسی می‌کنید و با افرادی کار می‌کنید که روی ویندوز نیستند (یا بالعکس)، احتمالاً دیر یا زود با مشکل پایان‌خط‌ها روبه‌رو خواهید شد.
+علت این است که ویندوز برای نشانه‌گذاری خطوط جدید از هر دو کاراکتر carriage-return و linefeed استفاده می‌کند، در حالی که macOS و لینوکس تنها از کاراکتر linefeed بهره می‌برند.
+این یک نکتهٔ ظریف اما بسیار آزاردهنده در کار میان‌پلتفرمی است؛ بسیاری از ویرایشگرها در ویندوز به‌صورت پنهانی پایان‌خط‌های به‌سبک LF را به CRLF تبدیل می‌کنند، یا هنگام فشردن کلید Enter هر دو کاراکتر پایان‌خط را وارد می‌کنند.
 
-Git can handle this by auto-converting CRLF line endings into LF when you add a file to the index, and vice versa when it checks out code onto your filesystem.
-You can turn on this functionality with the `core.autocrlf` setting.
-If you're on a Windows machine, set it to `true` -- this converts LF endings into CRLF when you check out code:
+گیت می‌تواند با تبدیل خودکار پایان‌خط‌های CRLF به LF هنگام افزودن فایل به ایندکس و بالعکس هنگام بیرون‌کشیدن کد به سیستم فایل شما با این وضعیت کنار بیاید.
+می‌توانید این قابلیت را با تنظیم `core.autocrlf` فعال کنید.
+اگر روی ماشین ویندوز هستید، آن را روی `true` قرار دهید -- این کار هنگام بیرون‌کشیدن کد، پایان‌خط‌های LF را به CRLF تبدیل می‌کند:
 
 [source,console]
 ----
 $ git config --global core.autocrlf true
 ----
 
-If you're on a Linux or macOS system that uses LF line endings, then you don't want Git to automatically convert them when you check out files; however, if a file with CRLF endings accidentally gets introduced, then you may want Git to fix it.
-You can tell Git to convert CRLF to LF on commit but not the other way around by setting `core.autocrlf` to `input`:
+اگر روی سیستم لینوکس یا macOS هستید که از پایان‌خط‌های LF استفاده می‌کنند، معمولاً نمی‌خواهید گیت به‌صورت خودکار هنگام بیرون‌کشیدن فایل‌ها آن‌ها را تبدیل کند؛ با این حال اگر به‌طور تصادفی فایلی با پایان‌خط CRLF وارد شود، ممکن است بخواهید گیت آن را اصلاح کند.
+می‌توانید به گیت بگویید که CRLF را هنگام commit به LF تبدیل کند اما عکس این کار را انجام ندهد، با قرار دادن `core.autocrlf` روی `input`:
 
 [source,console]
 ----
 $ git config --global core.autocrlf input
 ----
 
-This setup should leave you with CRLF endings in Windows checkouts, but LF endings on macOS and Linux systems and in the repository.
+این تنظیم باید در خروجی‌های checkout روی ویندوز پایان‌خط‌های CRLF و در macOS و لینوکس پایان‌خط‌های LF را حفظ کند.
 
-If you're a Windows programmer doing a Windows-only project, then you can turn off this functionality, recording the carriage returns in the repository by setting the config value to `false`:
+ اگر برنامه‌نویس ویندوز هستید و روی پروژه‌ای ویژهٔ ویندوز کار می‌کنید، می‌توانید این قابلیت را غیرفعال کنید و بازگشت‌خط‌ها (carriage return) را در مخزن ذخیره کنید، با تنظیم مقدار پیکربندی روی false:
 
 [source,console]
 ----
@@ -426,16 +421,22 @@ $ git config --global core.autocrlf false
 
 ===== `core.whitespace`
 
-Git comes preset to detect and fix some whitespace issues.
-It can look for six primary whitespace issues -- three are enabled by default and can be turned off, and three are disabled by default but can be activated.
+Git به‌صورت پیش‌فرض برخی از مشکلات فاصله‌گذاری (whitespace) را تشخیص داده و تصحیح می‌کند.
+این ابزار می‌تواند به‌دنبال شش مشکل اصلی مربوط به فاصله‌ها بگردد -- سه مورد به‌طور پیش‌فرض فعال هستند و قابل خاموش کردن‌اند، و سه مورد به‌طور پیش‌فرض غیرفعال‌اند اما قابل فعال‌سازی هستند.
 
-The three that are turned on by default are `blank-at-eol`, which looks for spaces at the end of a line; `blank-at-eof`, which notices blank lines at the end of a file; and `space-before-tab`, which looks for spaces before tabs at the beginning of a line.
+سه موردی که به‌طور پیش‌فرض روشن‌اند عبارت‌اند از:
+- blank-at-eol که به دنبال فاصله‌ها در پایان خط می‌گردد؛
+- blank-at-eof که خطوط خالی در پایان فایل را تشخیص می‌دهد؛
+- space-before-tab که به دنبال فاصله‌های قبل از تب در ابتدای خط می‌گردد.
 
-The three that are disabled by default but can be turned on are `indent-with-non-tab`, which looks for lines that begin with spaces instead of tabs (and is controlled by the `tabwidth` option); `tab-in-indent`, which watches for tabs in the indentation portion of a line; and `cr-at-eol`, which tells Git that carriage returns at the end of lines are OK.
+سه موردی که به‌طور پیش‌فرض خاموش‌اند اما می‌توان آن‌ها را روشن کرد عبارت‌اند از:
+- indent-with-non-tab که به دنبال خطوطی می‌گردد که به‌جای تب با فاصله‌ها شروع شده‌اند (و توسط گزینهٔ tabwidth کنترل می‌شود)؛
+- tab-in-indent که برای تب‌ها در بخش تورفتگی (indentation) خط نظارت می‌کند؛
+- cr-at-eol که به Git می‌گوید وجود carriage return در انتهای خطوط مجاز است.
 
-You can tell Git which of these you want enabled by setting `core.whitespace` to the values you want on or off, separated by commas.
-You can disable an option by prepending a `-` in front of its name, or use the default value by leaving it out of the setting string entirely.
-For example, if you want all but `space-before-tab` to be set, you can do this (with `trailing-space` being a short-hand to cover both `blank-at-eol` and `blank-at-eof`):
+می‌توانید به Git بگویید کدام‌یک از این گزینه‌ها را فعال می‌خواهید با تنظیم core.whitespace روی مقادیر موردنظر، جدا‌شده با ویرگول.
+می‌توانید یک گزینه را با قرار دادن یک - قبل از نامش غیرفعال کنید، یا اگر بخواهید مقدار پیش‌فرض را حفظ کنید آن گزینه را اصلاً در رشتهٔ تنظیمات نیاورید.
+برای مثال، اگر بخواهید همهٔ گزینه‌ها به‌جز space-before-tab فعال باشند، می‌توانید این کار را انجام دهید (trailing-space به‌صورت کوتاه‌نویس هر دو گزینهٔ blank-at-eol و blank-at-eof را شامل می‌شود):
 
 [source,console]
 ----
@@ -443,7 +444,7 @@ $ git config --global core.whitespace \
     trailing-space,-space-before-tab,indent-with-non-tab,tab-in-indent,cr-at-eol
 ----
 
-Or you can specify the customizing part only:
+یا فقط بخش سفارشی‌سازی را مشخص کنید:
 
 [source,console]
 ----
@@ -451,67 +452,66 @@ $ git config --global core.whitespace \
     -space-before-tab,indent-with-non-tab,tab-in-indent,cr-at-eol
 ----
 
-Git will detect these issues when you run a `git diff` command and try to color them so you can possibly fix them before you commit.
-It will also use these values to help you when you apply patches with `git apply`.
-When you're applying patches, you can ask Git to warn you if it's applying patches with the specified whitespace issues:
+Git این مشکلات را هنگام اجرای دستور git diff شناسایی می‌کند و سعی می‌کند آن‌ها را رنگی نشان دهد تا ممکن باشد قبل از commit آن‌ها را اصلاح کنید.
+همچنین از این مقادیر هنگام اعمال پچ‌ها با git apply برای کمک به شما استفاده می‌کند.
+وقتی پچ‌ها را اعمال می‌کنید، می‌توانید از Git بخواهید به شما هشدار دهد اگر پچ‌ها دارای مشکلات فاصله‌گذاری مشخص‌شده باشند:
 
 [source,console]
 ----
 $ git apply --whitespace=warn <patch>
 ----
 
-Or you can have Git try to automatically fix the issue before applying the patch:
+یا می‌توانید از Git بخواهید قبل از اعمال پچ تلاش کند مشکل را به‌صورت خودکار اصلاح کند:
 
 [source,console]
 ----
 $ git apply --whitespace=fix <patch>
 ----
 
-These options apply to the `git rebase` command as well.
-If you've committed whitespace issues but haven't yet pushed upstream, you can run `git rebase --whitespace=fix` to have Git automatically fix whitespace issues as it's rewriting the patches.
+ این گزینه‌ها برای دستور `git rebase` نیز اعمال می‌شوند.
+اگر شما تغییراتی شامل مشکلات فاصله‌گذاری (whitespace) را کامیت کرده‌اید اما هنوز به مخزن راه دور (upstream) پوش نکرده‌اید، می‌توانید با اجرای `git rebase --whitespace=fix` اجازه دهید گیت هنگام بازنویسی پچ‌ها به‌طور خودکار مشکلات فاصله‌گذاری را اصلاح کند.
 
-==== Server Configuration
 
-Not nearly as many configuration options are available for the server side of Git, but there are a few interesting ones you may want to take note of.
+گزینه‌های پیکربندی سمت سرور گیت به اندازه سمت کلاینت زیاد نیستند، اما چند گزینهٔ جالب وجود دارد که شاید بخواهید به آن‌ها توجه کنید.
 
 ===== `receive.fsckObjects`
 
-Git is capable of making sure every object received during a push still matches its SHA-1 checksum and points to valid objects.
-However, it doesn't do this by default; it's a fairly expensive operation, and might slow down the operation, especially on large repositories or pushes.
-If you want Git to check object consistency on every push, you can force it to do so by setting `receive.fsckObjects` to true:
+گیت قادر است بررسی کند هر آبجکت دریافتی در هنگام پوش هنوز با چکسام SHA-1 خود مطابقت دارد و به آبجکت‌های معتبر اشاره می‌کند.
+با این حال، این کار به‌طور پیش‌فرض انجام نمی‌شود؛ زیرا عملی نسبتاً هزینه‌بر است و ممکن است عملیات را کند کند، به‌ویژه در مخازن بزرگ یا پوش‌های حجیم.
+اگر می‌خواهید گیت در هر پوش سازگاری آبجکت‌ها را بررسی کند، می‌توانید با تنظیم `receive.fsckObjects` به true آن را مجبور به انجام این کار کنید:
 
 [source,console]
 ----
 $ git config --system receive.fsckObjects true
 ----
 
-Now, Git will check the integrity of your repository before each push is accepted to make sure faulty (or malicious) clients aren't introducing corrupt data.
+حال گیت قبل از پذیرفتن هر پوش، یک بررسی یکپارچگی روی مخزن انجام می‌دهد تا مطمئن شود کلاینت‌های خراب (یا مخرب) دادهٔ معیوب وارد نمی‌کنند.
 
 ===== `receive.denyNonFastForwards`
 
-If you rebase commits that you've already pushed and then try to push again, or otherwise try to push a commit to a remote branch that doesn't contain the commit that the remote branch currently points to, you'll be denied.
-This is generally good policy; but in the case of the rebase, you may determine that you know what you're doing and can force-update the remote branch with a `-f` flag to your push command.
+اگر کامیت‌هایی را که قبلاً پوش کرده‌اید ری‌بیس کنید و سپس دوباره بخواهید پوش کنید، یا به‌طور کلی بخواهید کامیتی را به برنچی در راه دور پوش کنید که آن برنچ شامل آن کامیت نیست، درخواست شما رد خواهد شد.
+این به‌طور کلی سیاست خوبی است؛ اما در حالت ری‌بیس ممکن است شما بدانید چه می‌کنید و بتوانید با افزودن فلگ `-f` به دستور پوش، برنچ راه دور را به‌زور بروزرسانی (force-update) کنید.
 
-To tell Git to refuse force-pushes, set `receive.denyNonFastForwards`:
+برای این‌که به گیت بگویید پوش‌های اجباری (force-push) را نپذیرد، مقدار `receive.denyNonFastForwards` را تنظیم کنید:
 
 [source,console]
 ----
 $ git config --system receive.denyNonFastForwards true
 ----
 
-The other way you can do this is via server-side receive hooks, which we'll cover in a bit.
-That approach lets you do more complex things like deny non-fast-forwards to a certain subset of users.
+راه دیگر برای این کار استفاده از هوک‌های سمت سرور برای دریافت (receive hooks) است که اندکی بعد به آن می‌پردازیم.
+این رویکرد به شما اجازه می‌دهد کارهای پیچیده‌تری انجام دهید، مثل جلوگیری از non-fast-forward برای زیرمجموعهٔ خاصی از کاربران.
 
 ===== `receive.denyDeletes`
 
-One of the workarounds to the `denyNonFastForwards` policy is for the user to delete the branch and then push it back up with the new reference.
-To avoid this, set `receive.denyDeletes` to true:
+یکی از راه‌حل‌ها برای سیاست `denyNonFastForwards` این است که کاربر شاخه را حذف کند و سپس آن را با ارجاع جدید دوباره پوش کند.
+برای جلوگیری از این کار، `receive.denyDeletes` را روی true تنظیم کنید:
 
 [source,console]
 ----
 $ git config --system receive.denyDeletes true
 ----
 
-This denies any deletion of branches or tags -- no user can do it.
-To remove remote branches, you must remove the ref files from the server manually.
-There are also more interesting ways to do this on a per-user basis via ACLs, as you'll learn in <<ch08-customizing-git#_an_example_git_enforced_policy>>.
+ این از حذف هرگونه شاخه یا تگ جلوگیری می‌کند — هیچ کاربری قادر به انجام آن نیست.
+برای حذف شاخه‌های راه دور، باید به‌صورت دستی فایل‌های ref را از روی سرور پاک کنید.
+همچنین روش‌های جالب‌تری برای انجام این کار به‌صورت تفکیک‌شده برای هر کاربر از طریق ACLها وجود دارد که در <<ch08-customizing-git#_an_example_git_enforced_policy>> خواهید آموخت.

--- a/book/08-customizing-git/sections/hooks.asc
+++ b/book/08-customizing-git/sections/hooks.asc
@@ -1,131 +1,131 @@
 [[_git_hooks]]
-=== Git Hooks
+=== Git Hooks (هوک‌های Git)
 
 (((hooks)))
-Like many other Version Control Systems, Git has a way to fire off custom scripts when certain important actions occur.
-There are two groups of these hooks: client-side and server-side.
-Client-side hooks are triggered by operations such as committing and merging, while server-side hooks run on network operations such as receiving pushed commits.
-You can use these hooks for all sorts of reasons.
+مثل بسیاری از سامانه‌های کنترل نسخه دیگر، Git راهی دارد تا هنگام رخ‌دادن بعضی عملیات مهم، اسکریپت‌های سفارشی را اجرا کند.
+دو گروه از این هوک‌ها وجود دارد: سمتِ کلاینت و سمتِ سرور.
+هوک‌های سمتِ کلاینت با عملیاتی مانند commit و merge فعال می‌شوند، در حالی که هوک‌های سمتِ سرور هنگام عملیات شبکه‌ای مثل دریافت commitهای push شده اجرا می‌گردند.
+می‌توانید از این هوک‌ها برای اهداف گوناگون استفاده کنید.
 
-==== Installing a Hook
+==== Installing a Hook (نصب یک هوک)
 
-The hooks are all stored in the `hooks` subdirectory of the Git directory.
-In most projects, that's `.git/hooks`.
-When you initialize a new repository with `git init`, Git populates the hooks directory with a bunch of example scripts, many of which are useful by themselves; but they also document the input values of each script.
-All the examples are written as shell scripts, with some Perl thrown in, but any properly named executable scripts will work fine – you can write them in Ruby or Python or whatever language you are familiar with.
-If you want to use the bundled hook scripts, you'll have to rename them; their file names all end with `.sample`.
+همهٔ هوک‌ها در زیرپوشهٔ `hooks` در دایرکتوری Git ذخیره می‌شوند.
+در اکثر پروژه‌ها این مسیر `.git/hooks` است.
+وقتی یک مخزن جدید را با `git init` مقداردهی می‌کنید، Git پوشهٔ hooks را با مجموعه‌ای از اسکریپت‌های نمونه پر می‌کند که بسیاری از آن‌ها به‌خودی‌خود مفیدند؛ همچنین ورودی‌ها و پارامترهای هر اسکریپت را مستندسازی می‌کنند.
+تمام نمونه‌ها به‌صورت اسکریپت شل نوشته شده‌اند و برخی هم از Perl استفاده می‌کنند، اما هر اسکریپت اجرایی‌ای که نام مناسبی داشته باشد به‌خوبی کار خواهد کرد - می‌توانید آن‌ها را به Ruby یا Python یا هر زبانی که با آن راحت‌اید بنویسید.
+اگر می‌خواهید از اسکریپت‌های بسته‌بندی‌شده استفاده کنید، باید نام آن‌ها را تغییر دهید؛ نام فایل‌های آن‌ها همگی با `.sample` خاتمه یافته است.
 
-To enable a hook script, put a file in the `hooks` subdirectory of your `.git` directory that is named appropriately (without any extension) and is executable.
-From that point forward, it should be called.
-We'll cover most of the major hook filenames here.
+برای فعال کردن یک اسکریپت هوک، فایلی در زیرپوشهٔ hooks پوشهٔ .git خود قرار دهید که نام آن به‌درستی انتخاب شده باشد (بدون پسوند) و قابل اجرا باشد.
+از آن زمان به بعد، این اسکریپت فراخوانی خواهد شد.
+در ادامه نام‌های فایلِ بیش‌ترین هوک‌های مهم را پوشش می‌دهیم.
 
-==== Client-Side Hooks
+==== Client-Side Hooks (هوک‌های سمتِ کلاینت)
 
-There are a lot of client-side hooks.
-This section splits them into committing-workflow hooks, email-workflow scripts, and everything else.
+هوک‌های سمتِ کلاینت زیادی وجود دارند.
+این بخش آن‌ها را به هوک‌های جریان کار commit، اسکریپت‌های جریان کار ایمیل، و سایر موارد تقسیم می‌کند.
 
 [NOTE]
 ====
-It's important to note that client-side hooks are *not* copied when you clone a repository.
-If your intent with these scripts is to enforce a policy, you'll probably want to do that on the server side; see the example in <<ch08-customizing-git#_an_example_git_enforced_policy>>.
+مهم است بدانید که هوک‌های سمتِ کلاینت هنگام clone شدنِ مخزن کپی **نمی‌شوند**.
+اگر هدف‌تان از این اسکریپت‌ها اعمال یک سیاست است، احتمالاً می‌خواهید آن را در سمتِ سرور اعمال کنید؛ نمونه‌ای از این مورد را در <<ch08-customizing-git#_an_example_git_enforced_policy>> ببینید.
 ====
 
-===== Committing-Workflow Hooks
+===== Committing-Workflow Hooks (هوک‌های مرتبط با جریان کار)
 
-The first four hooks have to do with the committing process.
+چهار هوک اول مربوط به فرایند commit هستند.
 
-The `pre-commit` hook is run first, before you even type in a commit message.
-It's used to inspect the snapshot that's about to be committed, to see if you've forgotten something, to make sure tests run, or to examine whatever you need to inspect in the code.
-Exiting non-zero from this hook aborts the commit, although you can bypass it with `git commit --no-verify`.
-You can do things like check for code style (run `lint` or something equivalent), check for trailing whitespace (the default hook does exactly this), or check for appropriate documentation on new methods.
+هوک `pre-commit` اولین هوکی است که اجرا می‌شود، حتی قبل از اینکه پیام کامیت را وارد کنید.
+این هوک برای بررسی اسنپ‌شاتی که قرار است کامیت شود به کار می‌رود؛ برای دیدن اینکه چیزی را فراموش نکرده‌اید، اطمینان از اجرای تست‌ها، یا بررسی هر چیزی که لازم است در کد بازدید شود.
+خروج با کد غیرصفر از این هوک باعث لغو کامیت می‌شود، اگرچه می‌توانید با استفاده از `git commit --no-verify` آن را دور بزنید.
+می‌توانید کارهایی مثل بررسی سبک کد (اجرای lint یا معادل آن)، بررسی فاصله‌های انتهایی سطرها (هوک پیش‌فرض دقیقاً همین را انجام می‌دهد)، یا بررسی مستندات مناسب برای متدهای جدید را انجام دهید.
 
-The `prepare-commit-msg` hook is run before the commit message editor is fired up but after the default message is created.
-It lets you edit the default message before the commit author sees it.
-This hook takes a few parameters: the path to the file that holds the commit message so far, the type of commit, and the commit SHA-1 if this is an amended commit.
-This hook generally isn't useful for normal commits; rather, it's good for commits where the default message is auto-generated, such as templated commit messages, merge commits, squashed commits, and amended commits.
-You may use it in conjunction with a commit template to programmatically insert information.
+هوک `prepare-commit-msg` قبل از باز شدن ویرایشگر پیام کامیت ولی پس از ساخته شدن پیام پیش‌فرض اجرا می‌شود.
+این امکان را به شما می‌دهد که پیام پیش‌فرض را قبل از اینکه نویسندهٔ کامیت آن را ببیند ویرایش کنید.
+این هوک چند پارامتر می‌گیرد: مسیر فایلی که تا کنون پیام کامیت در آن ذخیره شده، نوع کامیت، و `SHA-1` کامیت در صورتی که این یک کامیت اصلاح‌شده (amended) باشد.
+این هوک معمولاً برای کامیت‌های معمولی مفید نیست؛ بلکه برای کامیت‌هایی مناسب است که پیام پیش‌فرض به‌صورت خودکار تولید می‌شود، مثل پیام‌های قالبی، کامیت‌های `merge`، کامیت‌های `squash` شده، و کامیت‌های اصلاح‌شده.
+می‌توانید آن را همراه با یک قالب پیام کامیت به‌کار ببرید تا اطلاعات را برنامه‌ریزی‌شده وارد کنید.
 
-The `commit-msg` hook takes one parameter, which again is the path to a temporary file that contains the commit message written by the developer.
-If this script exits non-zero, Git aborts the commit process, so you can use it to validate your project state or commit message before allowing a commit to go through.
-In the last section of this chapter, we'll demonstrate using this hook to check that your commit message is conformant to a required pattern.
+هوک `commit-msg` یک پارامتر می‌گیرد که آن هم مسیر یک فایل موقت است که پیام کامیت نوشته‌شده توسط توسعه‌دهنده را در خود دارد.
+اگر این اسکریپت با کد غیرصفر خارج شود، گیت فرایند کامیت را متوقف می‌کند، بنابراین می‌توانید از آن برای اعتبارسنجی وضعیت پروژه یا پیام کامیت پیش از اجازه‌دادن به انجام کامیت استفاده کنید.
+در بخش آخر این فصل، نشان خواهیم داد چگونه از این هوک برای بررسی تطابق پیام کامیت با یک الگوی موردنیاز استفاده کنید.
 
-After the entire commit process is completed, the `post-commit` hook runs.
-It doesn't take any parameters, but you can easily get the last commit by running `git log -1 HEAD`.
-Generally, this script is used for notification or something similar.
+    پس از تکمیل کل فرایند کامیت، هوک `post-commit` اجرا می‌شود.
+این هوک پارامتری نمی‌گیرد، اما به‌راحتی می‌توانید آخرین کامیت را با اجرای `git log -1 HEAD` بگیرید.
+به‌طور کلی، این اسکریپت برای اعلان یا کارهای مشابه استفاده می‌شود.
 
 [[_email_hooks]]
-===== Email Workflow Hooks
+===== Email Workflow Hooks (قلاب‌های جریان کاری ایمیل)
 
-You can set up three client-side hooks for an email-based workflow.
-They're all invoked by the `git am` command, so if you aren't using that command in your workflow, you can safely skip to the next section.
-If you're taking patches over email prepared by `git format-patch`, then some of these may be helpful to you.
+می‌توانید سه قلاب سمت کلاینت برای یک جریان کاری مبتنی بر ایمیل تنظیم کنید.
+همهٔ این‌ها توسط فرمان `git am` فراخوانی می‌شوند، بنابراین اگر از آن فرمان در جریان کاری‌تان استفاده نمی‌کنید، می‌توانید به‌راحتی به بخش بعدی بروید.
+اگر پچ‌هایی که از طریق ایمیل می‌گیرید را با `git format-patch` آماده می‌کنید، برخی از این قلاب‌ها ممکن است برایتان مفید باشند.
 
-The first hook that is run is `applypatch-msg`.
-It takes a single argument: the name of the temporary file that contains the proposed commit message.
-Git aborts the patch if this script exits non-zero.
-You can use this to make sure a commit message is properly formatted, or to normalize the message by having the script edit it in place.
+اولین قلابی که اجرا می‌شود `applypatch-msg` است.
+این قلاب یک آرگومان می‌گیرد: نام فایل موقتی که پیام کمیت پیشنهادی در آن قرار دارد.
+اگر این اسکریپت با کد خروجی غیرصفر پایان یابد، گیت پچ را لغو می‌کند.
+می‌توانید از این برای اطمینان از قالب صحیح پیام کمیت استفاده کنید یا با ویرایش پیام در محل توسط اسکریپت، آن را نرمال‌سازی کنید.
 
-The next hook to run when applying patches via `git am` is `pre-applypatch`.
-Somewhat confusingly, it is run _after_ the patch is applied but before a commit is made, so you can use it to inspect the snapshot before making the commit.
-You can run tests or otherwise inspect the working tree with this script.
-If something is missing or the tests don't pass, exiting non-zero aborts the `git am` script without committing the patch.
+قلاب بعدی که هنگام اعمال پچ‌ها از طریق `git am` اجرا می‌شود `pre-applypatch` است.
+تا حدی گیج‌کننده است که این قلاب بعد از اعمال پچ ولی قبل از ساختن کمیت اجرا می‌شود، بنابراین می‌توانید از آن برای بررسی snapshot قبل از انجام کمیت استفاده کنید.
+می‌توانید با این اسکریپت تست‌ها را اجرا کنید یا درخت کاری را بررسی کنید.
+اگر چیزی کم است یا تست‌ها قبول نشدند، خروجی غیرصفر موجب لغو اسکریپت `git am` بدون ساختن کمیت می‌شود.
 
-The last hook to run during a `git am` operation is `post-applypatch`, which runs after the commit is made.
-You can use it to notify a group or the author of the patch you pulled in that you've done so.
-You can't stop the patching process with this script.
+آخرین قلابی که در یک عملیات `git am` اجرا می‌شود `post-applypatch` است که بعد از انجام کمیت اجرا می‌شود.
+می‌توانید از آن برای اطلاع‌رسانی به یک گروه یا نویسندهٔ پچی که دریافت کرده‌اید استفاده کنید که آن را اعمال کرده‌اید.
+با این اسکریپت نمی‌توانید فرایند اعمال پچ را متوقف کنید.
 
 [[_other_client_hooks]]
-===== Other Client Hooks
+===== Other Client Hooks (هوک های دیگر کلاینت)
 
-The `pre-rebase` hook runs before you rebase anything and can halt the process by exiting non-zero.
-You can use this hook to disallow rebasing any commits that have already been pushed.
-The example `pre-rebase` hook that Git installs does this, although it makes some assumptions that may not match with your workflow.
+قلاب `pre-rebase` قبل از انجام هر عمل ری‌بیس اجرا می‌شود و با خروج غیرصفر می‌تواند روند را متوقف کند.
+می‌توانید از این قلاب برای منع ری‌بیس کردن کامیت‌هایی که قبلاً پوش شده‌اند استفاده کنید.
+قلاب نمونه‌ی `pre-rebase` که گیت نصب می‌کند همین کار را انجام می‌دهد، هرچند که مفروضاتی دارد که ممکن است با جریان کاری شما همخوانی نداشته باشند.
 
-The `post-rewrite` hook is run by commands that replace commits, such as `git commit --amend` and `git rebase` (though not by `git filter-branch`).
-Its single argument is which command triggered the rewrite, and it receives a list of rewrites on `stdin`.
-This hook has many of the same uses as the `post-checkout` and `post-merge` hooks.
+قلاب `post-rewrite` توسط دستوراتی که کامیت‌ها را جایگزین می‌کنند اجرا می‌شود، مانند `git commit --amend` و `git rebase` (اما توسط `git filter-branch` اجرا نمی‌شود).
+آرگومان یکتای آن نشان‌دهنده‌ی دستوری است که بازنویسی را راه‌اندازی کرده و لیستی از بازنویسی‌ها را از طریق `stdin` دریافت می‌کند.
+این قلاب کاربردهای زیادی مشابه با قلاب‌های `post-checkout` و post-merge دارد.
 
-After you run a successful `git checkout`, the `post-checkout` hook runs; you can use it to set up your working directory properly for your project environment.
-This may mean moving in large binary files that you don't want source controlled, auto-generating documentation, or something along those lines.
+پس از اجرای موفقیت‌آمیز `git checkout`، قلاب `post-checkout` اجرا می‌شود؛ می‌توانید از آن برای آماده‌سازی درست درخت کاری پروژه‌تان استفاده کنید.
+این ممکن است شامل انتقال فایل‌های باینری حجیم که نمی‌خواهید تحت کنترل نسخه باشند، تولید خودکار مستندات، یا کارهایی مشابه باشد.
 
-The `post-merge` hook runs after a successful `merge` command.
-You can use it to restore data in the working tree that Git can't track, such as permissions data.
-This hook can likewise validate the presence of files external to Git control that you may want copied in when the working tree changes.
+قلاب `post-merge` پس از اجرای موفق `merge` اجرا می‌شود.
+می‌توانید از آن برای بازگرداندن داده‌هایی در درخت کاری که گیت قادر به دنبال کردنشان نیست مثل اطلاعات دسترسی (permissions) استفاده کنید.
+این قلاب همچنین می‌تواند وجود فایل‌های خارج از کنترل گیت را که می‌خواهید هنگام تغییر درخت کاری کپی شوند، اعتبارسنجی کند.
 
-The `pre-push` hook runs during `git push`, after the remote refs have been updated but before any objects have been transferred.
-It receives the name and location of the remote as parameters, and a list of to-be-updated refs through `stdin`.
-You can use it to validate a set of ref updates before a push occurs (a non-zero exit code will abort the push).
+قلاب `pre-push` طی `git push` اجرا می‌شود، پس از اینکه رفرنس‌های ریموت به‌روزرسانی شدند اما قبل از انتقال هر شیء.
+نام و مکان ریموت را به‌عنوان پارامتر دریافت می‌کند و لیستی از رفرنس‌هایی که قرار است به‌روزرسانی شوند را از طریق `stdin` می‌گیرد.
+می‌توانید از آن برای اعتبارسنجی مجموعه‌ای از به‌روزرسانی‌های رفرنس پیش از انجام push استفاده کنید (خروجی با کد غیرصفر باعث لغو push می‌شود).
 
-Git occasionally does garbage collection as part of its normal operation, by invoking `git gc --auto`.
-The `pre-auto-gc` hook is invoked just before the garbage collection takes place, and can be used to notify you that this is happening, or to abort the collection if now isn't a good time.
+گیت گهگاه به‌عنوان بخشی از عملیات عادی خود جمع‌آوری زباله انجام می‌دهد، با فراخوانی `git gc --auto`.
+هوک `pre-auto-gc` درست پیش از انجام جمع‌آوری زباله فراخوانی می‌شود و می‌تواند برای اطلاع‌رسانی اینکه این کار در حال انجام است یا برای لغو جمع‌آوری در صورتی که الان زمان مناسبی نباشد، استفاده شود.
 
-==== Server-Side Hooks
+==== Server-Side Hooks (قلاب‌های سمت سرور)
 
-In addition to the client-side hooks, you can use a couple of important server-side hooks as a system administrator to enforce nearly any kind of policy for your project.
-These scripts run before and after pushes to the server.
-The pre hooks can exit non-zero at any time to reject the push as well as print an error message back to the client; you can set up a push policy that's as complex as you wish.
+علاوه بر قلاب‌های سمت کلاینت، می‌توانید به عنوان مدیر سیستم از چند قلاب مهم سمت سرور برای اجرای تقریباً هر نوع سیاستی برای پروژه خود استفاده کنید.
+این اسکریپت‌ها قبل و بعد از push به سرور اجرا می‌شوند.
+قلاب‌های قبل از اجرا می‌توانند در هر زمانی با خروج غیرصفر، فشار را رد کنند و همچنین پیام خطایی را به مشتری برگردانند؛ شما می‌توانید یک سیاست فشار را به هر اندازه که می‌خواهید پیچیده تنظیم کنید.
 
 ===== `pre-receive`
 
-The first script to run when handling a push from a client is `pre-receive`.
-It takes a list of references that are being pushed from stdin; if it exits non-zero, none of them are accepted.
-You can use this hook to do things like make sure none of the updated references are non-fast-forwards, or to do access control for all the refs and files they're modifying with the push.
+اولین اسکریپتی که هنگام رسیدگی به push از سمت یک کلاینت اجرا می‌شود، `pre-receive` است.
+لیستی از مراجع را که از ورودی استاندارد (stdin) وارد می‌شوند، می‌گیرد؛ اگر با کد غیرصفر خارج شود، هیچ‌کدام از آن‌ها پذیرفته نمی‌شوند.
+می‌توانید از این قلاب برای کارهایی مانند اطمینان از اینکه هیچ یک از مراجع به‌روزرسانی‌شده غیرقابل پیشروی سریع نیستند، یا برای کنترل دسترسی به تمام مراجع و فایل‌هایی که با فشار تغییر می‌دهند، استفاده کنید.
 
 ===== `update`
 
-The `update` script is very similar to the `pre-receive` script, except that it's run once for each branch the pusher is trying to update.
-If the pusher is trying to push to multiple branches, `pre-receive` runs only once, whereas `update` runs once per branch they're pushing to.
-Instead of reading from stdin, this script takes three arguments: the name of the reference (branch), the SHA-1 that reference pointed to before the push, and the SHA-1 the user is trying to push.
-If the `update` script exits non-zero, only that reference is rejected; other references can still be updated.
+اسکریپت `update` بسیار شبیه به اسکریپت `pre-receive` است، با این تفاوت که برای هر شاخه‌ای که push کننده سعی در به‌روزرسانی آن دارد، یک بار اجرا می‌شود.
+اگر فشاردهنده سعی دارد به شاخه‌های متعددی فشار وارد کند، `pre-receive` فقط یک بار اجرا می‌شود، در حالی که `update` به ازای هر شاخه‌ای که به آن فشار وارد می‌کند، یک بار اجرا می‌شود.
+به جای خواندن از ورودی استاندارد، این اسکریپت سه آرگومان می‌گیرد: نام مرجع (شاخه)، هش SHA-1 که مرجع قبل از push به آن اشاره می‌کرد، و هش SHA-1 که کاربر در حال تلاش برای push کردن آن است.
+اگر اسکریپت `update` با کد خروج غیرصفر به پایان برسد، فقط آن مرجع رد می‌شود؛ سایر مراجع همچنان می‌توانند به‌روزرسانی شوند.
 
 ===== `post-receive`
 
-The `post-receive` hook runs after the entire process is completed and can be used to update other services or notify users.
-It takes the same stdin data as the `pre-receive` hook.
-Examples include emailing a list, notifying a continuous integration server, or updating a ticket-tracking system – you can even parse the commit messages to see if any tickets need to be opened, modified, or closed.
-This script can't stop the push process, but the client doesn't disconnect until it has completed, so be careful if you try to do anything that may take a long time.
+قلاب `post-receive` پس از تکمیل کل فرآیند اجرا می‌شود و می‌تواند برای به‌روزرسانی سرویس‌های دیگر یا اطلاع‌رسانی به کاربران استفاده شود.
+داده‌های ورودی استاندارد (stdin) مشابه قلاب `pre-receive` را دریافت می‌کند.
+نمونه‌هایی از این موارد شامل ارسال ایمیل به یک لیست، اطلاع‌رسانی به سرور یکپارچه‌سازی مداوم یا به‌روزرسانی سیستم ردیابی تیکت است – حتی می‌توانید پیام‌های کامیت را تجزیه و تحلیل کنید تا ببینید آیا نیاز به باز کردن، اصلاح یا بستن تیکتی وجود دارد یا خیر.
+این اسکریپت نمی‌تواند فرآیند فشار را متوقف کند، اما کلاینت تا زمانی که کامل نشده است قطع نمی‌شود، بنابراین اگر سعی دارید کاری انجام دهید که ممکن است زمان زیادی طول بکشد، مراقب باشید.
 
 [TIP]
 ====
-If you're writing a script/hook that others will need to read, prefer the long versions of command-line flags; six months from now you'll thank us.
+اگر در حال نوشتن اسکریپت/هوک هستید که دیگران باید آن را بخوانند، نسخه‌های طولانی‌تر پرچم‌های خط فرمان را ترجیح دهید؛ شش ماه دیگر از ما تشکر خواهید کرد.
 ====

--- a/book/08-customizing-git/sections/policy.asc
+++ b/book/08-customizing-git/sections/policy.asc
@@ -1,25 +1,25 @@
 [[_an_example_git_enforced_policy]]
-=== An Example Git-Enforced Policy
+=== An Example Git-Enforced Policy (یک نمونه سیاست اعمال شده توسط گیت)
 
 (((policy example)))
-In this section, you'll use what you've learned to establish a Git workflow that checks for a custom commit message format, and allows only certain users to modify certain subdirectories in a project.
-You'll build client scripts that help the developer know if their push will be rejected and server scripts that actually enforce the policies.
+در این بخش، از آنچه آموخته‌اید برای ایجاد یک گردش کار گیت استفاده خواهید کرد که قالب پیام‌های سفارشی را بررسی می‌کند و فقط به کاربران خاص اجازه می‌دهد زیرشاخه‌های خاصی را در یک پروژه تغییر دهند.
+شما اسکریپت‌های کلاینتی می‌سازید که به توسعه‌دهنده کمک می‌کند بفهمد آیا فشار او رد خواهد شد یا خیر، و اسکریپت‌های سروری که در واقع سیاست‌ها را اجرا می‌کنند.
 
-The scripts we'll show are written in Ruby; partly because of our intellectual inertia, but also because Ruby is easy to read, even if you can't necessarily write it.
-However, any language will work – all the sample hook scripts distributed with Git are in either Perl or Bash, so you can also see plenty of examples of hooks in those languages by looking at the samples.
+اسکریپت‌هایی که نشان خواهیم داد به زبان روبی نوشته شده‌اند؛ تا حدی به دلیل اینرسی فکری ما، اما همچنین به این دلیل که روبی خواندنش آسان است، حتی اگر لزوماً نتوانید آن را بنویسید.
+با این حال، هر زبانی کار می‌کند – تمام اسکریپت‌های قلاب نمونه که با گیت توزیع می‌شوند یا در پرل یا در باش هستند، بنابراین با نگاهی به نمونه‌ها می‌توانید مثال‌های زیادی از قلاب‌ها را در این زبان‌ها نیز ببینید.
 
-==== Server-Side Hook
+==== Server-Side Hook (قلاب سمت سرور )
 
-All the server-side work will go into the `update` file in your `hooks` directory.
-The `update` hook runs once per branch being pushed and takes three arguments:
+تمام کارهای سمت سرور در فایل `update` در دایرکتوری `hooks` شما قرار خواهد گرفت.
+قلاب `update` یک بار برای هر شاخه‌ای که push می‌شود اجرا می‌شود و سه آرگومان می‌گیرد:
 
-* The name of the reference being pushed to
-* The old revision where that branch was
-* The new revision being pushed
+* نام مرجعی که به آن فشار داده می‌شود
+* نسخه قدیمی که آن شاخه در آن قرار داشت
+* نسخه جدیدی که فشار داده می‌شود
 
-You also have access to the user doing the pushing if the push is being run over SSH.
-If you've allowed everyone to connect with a single user (like "`git`") via public-key authentication, you may have to give that user a shell wrapper that determines which user is connecting based on the public key, and set an environment variable accordingly.
-Here we'll assume the connecting user is in the `$USER` environment variable, so your update script begins by gathering all the information you need:
+اگر push از طریق SSH اجرا می‌شود، شما همچنین به کاربر انجام‌دهنده push دسترسی دارید.
+اگر به همه اجازه داده‌اید که از طریق احراز هویت با کلید عمومی به یک کاربر واحد (مانند `git`) متصل شوند، ممکن است مجبور شوید یک پوسته پوششی به آن کاربر بدهید که بر اساس کلید عمومی تعیین کند کدام کاربر در حال اتصال است و متغیر محیطی را بر این اساس تنظیم کند.
+در اینجا فرض می‌کنیم کاربر متصل در متغیر محیطی `$USER` قرار دارد، بنابراین اسکریپت به‌روزرسانی شما با جمع‌آوری تمام اطلاعات مورد نیازتان شروع می‌شود:
 
 [source,ruby]
 ----
@@ -34,19 +34,19 @@ puts "Enforcing Policies..."
 puts "(#{$refname}) (#{$oldrev[0,6]}) (#{$newrev[0,6]})"
 ----
 
-Yes, those are global variables.
-Don't judge – it's easier to demonstrate this way.
+بله، آن‌ها متغیرهای سراسری هستند.
+قضاوت نکن – این‌طوری نشان دادنش راحت‌تر است.
 
 [[_enforcing_commit_message_format]]
-===== Enforcing a Specific Commit-Message Format
+===== Enforcing a Specific Commit-Message Format (اعمال قالب خاصی برای پیام‌های commit)
 
-Your first challenge is to enforce that each commit message adheres to a particular format.
-Just to have a target, assume that each message has to include a string that looks like "`ref: 1234`" because you want each commit to link to a work item in your ticketing system.
-You must look at each commit being pushed up, see if that string is in the commit message, and, if the string is absent from any of the commits, exit non-zero so the push is rejected.
+اولین چالش شما این است که اطمینان حاصل کنید هر پیام کامیت از قالب خاصی پیروی می‌کند.
+فقط برای داشتن یک هدف، فرض کنید هر پیام باید شامل رشته‌ای باشد که شبیه "`ref: 1234`" است، زیرا می‌خواهید هر کامیت به یک مورد کاری در سیستم تیکتینگ شما پیوند داشته باشد.
+شما باید هر کامیت که آپلود می‌شود را بررسی کنید، ببینید آیا آن رشته در پیام کامیت وجود دارد یا خیر، و اگر رشته در هیچ یک از کامیت‌ها وجود نداشت، با کد غیرصفر خارج شوید تا آپلود رد شود.
 
-You can get a list of the SHA-1 values of all the commits that are being pushed by taking the `$newrev` and `$oldrev` values and passing them to a Git plumbing command called `git rev-list`.
-This is basically the `git log` command, but by default it prints out only the SHA-1 values and no other information.
-So, to get a list of all the commit SHA-1s introduced between one commit SHA-1 and another, you can run something like this:
+شما می‌توانید با گرفتن مقادیر `$newrev` و `$oldrev` و پاس دادن آن‌ها به یک دستور لوله‌کشی گیت به نام `git rev-list`، فهرستی از مقادیر SHA-1 تمام کامیت‌هایی که در حال push شدن هستند را دریافت کنید.
+این اساساً دستور `git log` است، اما به طور پیش‌فرض فقط مقادیر SHA-1 را چاپ می‌کند و هیچ اطلاعات دیگری را نمایش نمی‌دهد.
+بنابراین، برای دریافت لیستی از تمام شناسه SHA-1 کامیت‌های معرفی شده بین یک شناسه SHA-1 کامیت و دیگری، می‌توانید چیزی شبیه این را اجرا کنید:
 
 [source,console]
 ----
@@ -58,11 +58,11 @@ dfa04c9ef3d5197182f13fb5b9b1fb7717d2222a
 17716ec0f1ff5c77eff40b7fe912f9f6cfd0e475
 ----
 
-You can take that output, loop through each of those commit SHA-1s, grab the message for it, and test that message against a regular expression that looks for a pattern.
+شما می‌توانید آن خروجی را بگیرید، روی هر یک از آن SHA-1های کامیت حلقه بزنید، پیام آن را بگیرید و آن پیام را در برابر یک عبارت منظم که به دنبال یک الگو می‌گردد، آزمایش کنید.
 
-You have to figure out how to get the commit message from each of these commits to test.
-To get the raw commit data, you can use another plumbing command called `git cat-file`.
-We'll go over all these plumbing commands in detail in <<ch10-git-internals#ch10-git-internals>>; but for now, here's what that command gives you:
+تو باید یاد بگیری که چطور پیام هر کدام از این کامیت‌ها را بگیری تا تست کنی.
+برای گرفتن داده‌ی خام کامیت، می‌توانی از یک دستور plumbing دیگر به نام `git cat-file` استفاده کنی.
+ما تمام این دستورهای plumbing را به‌طور کامل در <<ch10-git-internals#ch10-git-internals>> بررسی خواهیم کرد؛ اما فعلاً، این چیزی است که آن دستور به تو می‌دهد:
 
 [source,console]
 ----
@@ -75,8 +75,8 @@ committer Scott Chacon <schacon@gmail.com> 1240030591 -0700
 Change the version number
 ----
 
-A simple way to get the commit message from a commit when you have the SHA-1 value is to go to the first blank line and take everything after that.
-You can do so with the `sed` command on Unix systems:
+یک راه ساده برای دریافت پیام commit از یک commit زمانی که مقدار SHA-1 را دارید، این است که به اولین خط خالی بروید و هر چیزی را که بعد از آن می‌آید بردارید.
+می‌توانید این کار را با دستور `sed` در سیستم‌های یونیکس انجام دهید:
 
 [source,console]
 ----
@@ -84,9 +84,9 @@ $ git cat-file commit ca82a6 | sed '1,/^$/d'
 Change the version number
 ----
 
-You can use that incantation to grab the commit message from each commit that is trying to be pushed and exit if you see anything that doesn't match.
-To exit the script and reject the push, exit non-zero.
-The whole method looks like this:
+می‌توانید از آن ورد برای گرفتن پیام commit از هر commit که در حال تلاش برای push شدن است استفاده کنید و اگر چیزی را مشاهده کردید که مطابقت نداشت، خارج شوید.
+برای خروج از اسکریپت و رد کردن پوش، با خروج غیرصفر خارج شوید.
+کل روش به این صورت است:
 
 [source,ruby]
 ----
@@ -106,20 +106,20 @@ end
 check_message_format
 ----
 
-Putting that in your `update` script will reject updates that contain commits that have messages that don't adhere to your rule.
+قرار دادن این در اسکریپت `update` شما، به‌روزرسانی‌هایی را که شامل کامیت‌هایی با پیام‌هایی هستند که از قانون شما پیروی نمی‌کنند، رد خواهد کرد.
 
-===== Enforcing a User-Based ACL System
+===== Enforcing a User-Based ACL System (اجرای یک سیستم ACL مبتنی بر کاربر)
 
-Suppose you want to add a mechanism that uses an access control list (ACL) that specifies which users are allowed to push changes to which parts of your projects.
-Some people have full access, and others can only push changes to certain subdirectories or specific files.
-To enforce this, you'll write those rules to a file named `acl` that lives in your bare Git repository on the server.
-You'll have the `update` hook look at those rules, see what files are being introduced for all the commits being pushed, and determine whether the user doing the push has access to update all those files.
+فرض کنید می‌خواهید مکانیزمی اضافه کنید که از فهرست کنترل دسترسی (ACL) استفاده می‌کند و مشخص می‌کند که کدام کاربران مجاز به اعمال تغییرات در کدام بخش‌های پروژه‌های شما هستند.
+برخی افراد دسترسی کامل دارند و برخی دیگر فقط می‌توانند تغییرات را به زیرشاخه‌های خاص یا فایل‌های مشخص فشار دهند.
+برای اعمال این، این قوانین را در فایلی به نام `acl` که در مخزن گیت برهنه شما در سرور قرار دارد، خواهید نوشت.
+شما قلاب `update` را طوری تنظیم می‌کنید که به این قوانین نگاه کند، ببیند چه فایل‌هایی برای تمام کامیت‌هایی که در حال push شدن هستند معرفی می‌شوند و تعیین کند که آیا کاربری که push را انجام می‌دهد، دسترسی به به‌روزرسانی تمام آن فایل‌ها را دارد یا خیر.
 
-The first thing you'll do is write your ACL.
-Here you'll use a format very much like the CVS ACL mechanism: it uses a series of lines, where the first field is `avail` or `unavail`, the next field is a comma-delimited list of the users to which the rule applies, and the last field is the path to which the rule applies (blank meaning open access).
-All of these fields are delimited by a pipe (`|`) character.
+اولین کاری که انجام می‌دهید نوشتن ACL خود است.
+در اینجا از فرمتی بسیار شبیه به مکانیسم ACL CVS استفاده خواهید کرد: این فرمت از یک سری خطوط استفاده می‌کند که در آن فیلد اول `avail` یا `unavail` است، فیلد بعدی لیستی از کاربران است که با کاما از هم جدا شده‌اند و قانون برای آنها اعمال می‌شود، و فیلد آخر مسیر اعمال قانون است (به معنی دسترسی آزاد).
+تمام این فیلدها با کاراکتر لوله (|) از هم جدا شده‌اند.
 
-In this case, you have a couple of administrators, some documentation writers with access to the `doc` directory, and one developer who only has access to the `lib` and `tests` directories, and your ACL file looks like this:
+در این مورد، شما چند مدیر، تعدادی نویسنده مستندات با دسترسی به دایرکتوری `doc` و یک توسعه‌دهنده دارید که فقط به دایرکتوری‌های `lib` و `tests` دسترسی دارد و فایل ACL شما به این شکل است:
 
 [source]
 ----
@@ -129,9 +129,9 @@ avail|schacon|lib
 avail|schacon|tests
 ----
 
-You begin by reading this data into a structure that you can use.
-In this case, to keep the example simple, you'll only enforce the `avail` directives.
-Here is a method that gives you an associative array where the key is the user name and the value is an array of paths to which the user has write access:
+شما با خواندن این داده‌ها در ساختاری که می‌توانید از آن استفاده کنید، شروع می‌کنید.
+در این مورد، برای ساده نگه داشتن مثال، فقط دستورالعمل‌های `avail` را اعمال خواهید کرد.
+این روشی است که به شما یک آرایه انجمنی می‌دهد که کلید آن نام کاربری و مقدار آن آرایه‌ای از مسیرهایی است که کاربر به آنها دسترسی نوشتن دارد:
 
 [source,ruby]
 ----
@@ -151,7 +151,7 @@ def get_acl_access_data(acl_file)
 end
 ----
 
-On the ACL file you looked at earlier, this `get_acl_access_data` method returns a data structure that looks like this:
+در فایل ACL که قبلاً بررسی کردید، این متد `get_acl_access_data` ساختار داده‌ای شبیه به این را برمی‌گرداند:
 
 [source,ruby]
 ----
@@ -165,9 +165,9 @@ On the ACL file you looked at earlier, this `get_acl_access_data` method returns
  "ebronte"=>["doc"]}
 ----
 
-Now that you have the permissions sorted out, you need to determine what paths the commits being pushed have modified, so you can make sure the user who's pushing has access to all of them.
+حالا که مجوزها را مرتب کرده‌اید، باید مشخص کنید که کامیت‌های در حال push چه مسیرهایی را تغییر داده‌اند تا مطمئن شوید کاربری که در حال push کردن است به همه آن‌ها دسترسی دارد.
 
-You can pretty easily see what files have been modified in a single commit with the `--name-only` option to the `git log` command (mentioned briefly in <<ch02-git-basics-chapter#ch02-git-basics-chapter>>):
+تو می‌توانی خیلی راحت ببینی که در یک کامیت چه فایل‌هایی تغییر کرده‌اند؛ با استفاده از گزینه‌ی --name-only در دستور git log (که به‌طور خلاصه در <<ch02-git-basics-chapter#ch02-git-basics-chapter>> اشاره شد):
 
 [source,console]
 ----
@@ -177,7 +177,7 @@ README
 lib/test.rb
 ----
 
-If you use the ACL structure returned from the `get_acl_access_data` method and check it against the listed files in each of the commits, you can determine whether the user has access to push all of their commits:
+اگر از ساختار ACL که از متد `get_acl_access_data` برگردانده شده استفاده کنید و آن را با فایل‌های فهرست شده در هر یک از کامیت‌ها مقایسه کنید، می‌توانید تعیین کنید که آیا کاربر به تمام کامیت‌های خود دسترسی دارد یا خیر:
 
 [source,ruby]
 ----
@@ -209,14 +209,14 @@ end
 check_directory_perms
 ----
 
-You get a list of new commits being pushed to your server with `git rev-list`.
-Then, for each of those commits, you find which files are modified and make sure the user who's pushing has access to all the paths being modified.
+با استفاده از دستور `git rev-list` لیستی از کامیت‌های جدیدی که به سرور شما push می‌شوند، دریافت می‌کنید.
+سپس، برای هر یک از آن کامیت‌ها، فایل‌های تغییر یافته را پیدا می‌کنید و مطمئن می‌شوید که کاربری که در حال پوش کردن است، به تمام مسیرهای در حال تغییر دسترسی دارد.
 
-Now your users can't push any commits with badly formed messages or with modified files outside of their designated paths.
+اکنون کاربران شما نمی‌توانند هیچ کامیتی را با پیام‌های بدشکل یا با فایل‌های اصلاح‌شده خارج از مسیرهای تعیین‌شده خود پوش کنند.
 
-===== Testing It Out
+===== Testing It Out (آزمایش آن)
 
-If you run `chmod u+x .git/hooks/update`, which is the file into which you should have put all this code, and then try to push a commit with a non-compliant message, you get something like this:
+اگر دستور `chmod u+x .git/hooks/update` را اجرا کنید، که فایل حاوی تمام این کد است، و سپس سعی کنید یک کامیت با پیام غیرمطابق را پوش کنید، چیزی شبیه این دریافت می‌کنید:
 
 [source,console]
 ----
@@ -236,8 +236,8 @@ To git@gitserver:project.git
 error: failed to push some refs to 'git@gitserver:project.git'
 ----
 
-There are a couple of interesting things here.
-First, you see this where the hook starts running.
+اینجا چند نکته‌ی جالب وجود دارد.
+اول، این بخش را می‌بینی که جایی است که هوک شروع به اجرا می‌کند.
 
 [source,console]
 ----
@@ -245,10 +245,10 @@ Enforcing Policies...
 (refs/heads/master) (fb8c72) (c56860)
 ----
 
-Remember that you printed that out at the very beginning of your update script.
-Anything your script echoes to `stdout` will be transferred to the client.
+یادت هست که این را در همان ابتدای اسکریپت به‌روزرسانی‌ات چاپ کردی؟
+هر چیزی که اسکریپت شما به `stdout` منعکس کند، به مشتری منتقل خواهد شد.
 
-The next thing you'll notice is the error message.
+چیز دیگری که متوجه آن خواهید شد، ارور است.
 
 [source,console]
 ----
@@ -257,8 +257,8 @@ error: hooks/update exited with error code 1
 error: hook declined to update refs/heads/master
 ----
 
-The first line was printed out by you, the other two were Git telling you that the update script exited non-zero and that is what is declining your push.
-Lastly, you have this:
+خط اول توسط شما چاپ شد، دو خط دیگر Git به شما می‌گوید که اسکریپت به‌روزرسانی با کد غیرصفر خارج شده است و این همان چیزی است که باعث رد شدن push شما می‌شود.
+ در نهایت، این را دارید:
 
 [source,console]
 ----
@@ -267,31 +267,31 @@ To git@gitserver:project.git
 error: failed to push some refs to 'git@gitserver:project.git'
 ----
 
-You'll see a remote rejected message for each reference that your hook declined, and it tells you that it was declined specifically because of a hook failure.
+برای هر مرجعی که قلاب شما رد کرده است، یک پیام رد شده از راه دور خواهید دید که به شما می‌گوید به طور خاص به دلیل شکست قلاب رد شده است.
 
-Furthermore, if someone tries to edit a file they don't have access to and push a commit containing it, they will see something similar.
-For instance, if a documentation author tries to push a commit modifying something in the `lib` directory, they see:
+علاوه بر این، اگر کسی سعی کند فایلی را که به آن دسترسی ندارد ویرایش کند و کامیتی حاوی آن را push کند، چیزی مشابه را خواهد دید.
+به عنوان مثال، اگر نویسنده مستندات سعی کند کامیتی را که چیزی را در دایرکتوری `lib` تغییر می‌دهد، فشار دهد، با این پیام مواجه می‌شود:
 
 [source,console]
 ----
 [POLICY] You do not have access to push to lib/test.rb
 ----
 
-From now on, as long as that `update` script is there and executable, your repository will never have a commit message without your pattern in it, and your users will be sandboxed.
+از این به بعد، تا زمانی که اسکریپت `update` وجود داشته باشد و قابل اجرا باشد، مخزن شما هرگز پیام کامیتی بدون الگوی شما نخواهد داشت و کاربران شما در یک محیط ایزوله قرار خواهند گرفت.
 
-==== Client-Side Hooks
+==== Client-Side Hooks (قلاب‌های سمت کلاینت )
 
-The downside to this approach is the whining that will inevitably result when your users' commit pushes are rejected.
-Having their carefully crafted work rejected at the last minute can be extremely frustrating and confusing; and furthermore, they will have to edit their history to correct it, which isn't always for the faint of heart.
+نقطه ضعف این رویکرد غرغره‌هایی است که به ناچار در صورت رد pushهای commit کاربران شما ایجاد می‌شود.
+رد شدن کار با دقت ساخته شده آنها در آخرین لحظه می‌تواند بسیار خسته‌کننده و گیج‌کننده باشد؛ و علاوه بر این، آنها باید تاریخچه خود را برای اصلاح آن ویرایش کنند، که همیشه برای افراد ضعیف‌القلب آسان نیست.
 
-The answer to this dilemma is to provide some client-side hooks that users can run to notify them when they're doing something that the server is likely to reject.
-That way, they can correct any problems before committing and before those issues become more difficult to fix.
-Because hooks aren't transferred with a clone of a project, you must distribute these scripts some other way and then have your users copy them to their `.git/hooks` directory and make them executable.
-You can distribute these hooks within the project or in a separate project, but Git won't set them up automatically.
+پاسخ به این معضل ارائه برخی قلاب‌های سمت مشتری است که کاربران می‌توانند آن‌ها را اجرا کنند تا در صورت انجام کاری که احتمالاً سرور آن را رد می‌کند، به آن‌ها اطلاع داده شود.
+به این ترتیب، می‌توانند هر مشکلی را قبل از تعهد و قبل از اینکه این مسائل سخت‌تر شوند، اصلاح کنند.
+چون قلاب‌ها با کپی یک پروژه منتقل نمی‌شوند، باید این اسکریپت‌ها را به روش دیگری توزیع کنید و سپس از کاربران خود بخواهید که آن‌ها را در دایرکتوری `.git/hooks` خود کپی کرده و قابل اجرا کنند.
+شما می‌توانید این قلاب‌ها را در داخل پروژه یا در یک پروژه جداگانه توزیع کنید، اما گیت آن‌ها را به طور خودکار راه‌اندازی نخواهد کرد.
 
-To begin, you should check your commit message just before each commit is recorded, so you know the server won't reject your changes due to badly formatted commit messages.
-To do this, you can add the `commit-msg` hook.
-If you have it read the message from the file passed as the first argument and compare that to the pattern, you can force Git to abort the commit if there is no match:
+برای شروع، باید پیام‌های کامیت خود را درست قبل از ثبت هر کامیت بررسی کنید تا بدانید سرور تغییرات شما را به دلیل پیام‌های کامیت با فرمت بد رد نخواهد کرد.
+برای این کار می‌توانید قلاب `commit-msg` را اضافه کنید.
+اگر آن را دارید، پیام فایل را که به عنوان آرگومان اول پاس داده شده است، بخوانید و آن را با الگو مقایسه کنید، می‌توانید گیت را مجبور کنید که اگر مطابقت وجود نداشت، از commit کردن منصرف شود:
 
 [source,ruby]
 ----
@@ -307,7 +307,7 @@ if !$regex.match(message)
 end
 ----
 
-If that script is in place (in `.git/hooks/commit-msg`) and executable, and you commit with a message that isn't properly formatted, you see this:
+اگر آن اسکریپت در جای خود (در `.git/hooks/commit-msg`) قرار داشته باشد و قابل اجرا باشد، و شما با پیامی که به درستی قالب‌بندی نشده است commit کنید، این را می‌بینید:
 
 [source,console]
 ----
@@ -315,8 +315,8 @@ $ git commit -am 'Test'
 [POLICY] Your message is not formatted correctly
 ----
 
-No commit was completed in that instance.
-However, if your message contains the proper pattern, Git allows you to commit:
+در آن نمونه هیچ کامیتی تکمیل نشد.
+با این حال، اگر پیام شما الگوی صحیح را داشته باشد، گیت به شما اجازه می‌دهد که commit کنید:
 
 [source,console]
 ----
@@ -325,8 +325,8 @@ $ git commit -am 'Test [ref: 132]'
  1 file changed, 1 insertions(+), 0 deletions(-)
 ----
 
-Next, you want to make sure you aren't modifying files that are outside your ACL scope.
-If your project's `.git` directory contains a copy of the ACL file you used previously, then the following `pre-commit` script will enforce those constraints for you:
+بعد، می‌خواهید مطمئن شوید که فایل‌هایی را که خارج از محدوده ACL شما هستند، تغییر نمی‌دهید.
+اگر دایرکتوری `.git` پروژه شما شامل کپی از فایل ACL است که قبلاً استفاده کرده‌اید، اسکریپت `pre-commit` زیر این محدودیت‌ها را برای شما اعمال خواهد کرد:
 
 [source,ruby]
 ----
@@ -358,9 +358,9 @@ end
 check_directory_perms
 ----
 
-This is roughly the same script as the server-side part, but with two important differences.
-First, the ACL file is in a different place, because this script runs from your working directory, not from your `.git` directory.
-You have to change the path to the ACL file from this:
+این تقریباً همان اسکریپت قسمت سمت سرور است، اما با دو تفاوت مهم.
+اولاً، فایل ACL در مکان دیگری قرار دارد، زیرا این اسکریپت از دایرکتوری کاری شما اجرا می‌شود، نه از دایرکتوری `.git` شما.
+شما باید مسیر فایل ACL را از این به این تغییر دهید:
 
 [source,ruby]
 ----
@@ -374,34 +374,34 @@ to this:
 access = get_acl_access_data('.git/acl')
 ----
 
-The other important difference is the way you get a listing of the files that have been changed.
-Because the server-side method looks at the log of commits, and, at this point, the commit hasn't been recorded yet, you must get your file listing from the staging area instead.
-Instead of:
+تفاوت مهم دیگر نحوه دریافت فهرست فایل‌هایی است که تغییر کرده‌اند.
+چون متد سمت سرور به لاگ کامیت‌ها نگاه می‌کند و در این مرحله کامیت هنوز ثبت نشده است، باید لیست فایل‌های خود را از ناحیه آماده‌سازی دریافت کنید.
+به جای:
 
 [source,ruby]
 ----
 files_modified = `git log -1 --name-only --pretty=format:'' #{ref}`
 ----
 
-you have to use:
+شما باید از این استفاده کنید:
 
 [source,ruby]
 ----
 files_modified = `git diff-index --cached --name-only HEAD`
 ----
 
-But those are the only two differences – otherwise, the script works the same way.
-One caveat is that it expects you to be running locally as the same user you push as to the remote machine.
-If that is different, you must set the `$user` variable manually.
+اما این تنها دو تفاوت است - در غیر این صورت، اسکریپت به همان روش کار می‌کند.
+یک نکته این است که انتظار دارد شما را به صورت محلی با همان کاربری که به ماشین راه دور پوش می‌کنید، اجرا کنید.
+اگر این متفاوت است، باید متغیر `$user` را به صورت دستی تنظیم کنید.
 
-One other thing we can do here is make sure the user doesn't push non-fast-forwarded references.
-To get a reference that isn't a fast-forward, you either have to rebase past a commit you've already pushed up or try pushing a different local branch up to the same remote branch.
+یک کار دیگر که می‌توانیم اینجا انجام دهیم این است که مطمئن شویم کاربر مراجع غیر fast-forward را push نمی‌کند.
+برای اینکه یک مرجع غیر از جلو بردن سریع داشته باشید، یا باید مبنای یک کامیت که قبلاً آن را پوش کرده‌اید را تغییر دهید یا سعی کنید یک شاخه محلی متفاوت را به همان شاخه ریموت پوش کنید.
 
-Presumably, the server is already configured with `receive.denyDeletes` and `receive.denyNonFastForwards` to enforce this policy, so the only accidental thing you can try to catch is rebasing commits that have already been pushed.
+احتمالاً سرور از قبل با `receive.denyDeletes` و `receive.denyNonFastForwards` پیکربندی شده است تا این سیاست را اجرا کند، بنابراین تنها چیزی که می‌توانید به طور تصادفی سعی کنید بگیرید، بازسازی کامیت‌هایی است که قبلاً پوش شده‌اند.
 
-Here is an example pre-rebase script that checks for that.
-It gets a list of all the commits you're about to rewrite and checks whether they exist in any of your remote references.
-If it sees one that is reachable from one of your remote references, it aborts the rebase.
+در اینجا یک مثال از اسکریپت قبل از ریبیس وجود دارد که این موضوع را بررسی می‌کند.
+این لیست تمام کامیت‌هایی را که قرار است بازنویسی کنید، دریافت می‌کند و بررسی می‌کند که آیا در هیچ یک از مراجع دوردست شما وجود دارند یا خیر.
+اگر یکی از مراجع دوردست شما را ببیند که قابل دسترسی است، عملیات rebase را متوقف می‌کند.
 
 [source,ruby]
 ----
@@ -428,16 +428,16 @@ target_shas.each do |sha|
 end
 ----
 
-This script uses a syntax that wasn't covered in <<ch07-git-tools#_revision_selection>>.
-You get a list of commits that have already been pushed up by running this:
+این اسکریپت از یک سینتکس استفاده می‌کند که در <<ch07-git-tools#_revision_selection>> پوشش داده نشده بود.
+با اجرای این دستور، فهرستی از کامیت‌هایی که قبلاً پوش شده‌اند را به دست می‌آوری:
 
 [source,ruby]
 ----
 `git rev-list ^#{sha}^@ refs/remotes/#{remote_ref}`
 ----
 
-The `SHA^@` syntax resolves to all the parents of that commit.
-You're looking for any commit that is reachable from the last commit on the remote and that isn't reachable from any parent of any of the SHA-1s you're trying to push up – meaning it's a fast-forward.
+سینتکس SHA^@ به همه‌ی والدهای آن کامیت اشاره می‌کند.
+تو دنبال هر کامیتی هستی که از آخرین کامیت روی ریموت قابل دسترسی باشد و از هیچ‌یک از والدهای هرکدام از SHA-1هایی که می‌خواهی پوش کنی قابل دسترسی نباشد — یعنی یک fast-forward است.
 
-The main drawback to this approach is that it can be very slow and is often unnecessary – if you don't try to force the push with `-f`, the server will warn you and not accept the push.
-However, it's an interesting exercise and can in theory help you avoid a rebase that you might later have to go back and fix.
+نقطه ضعف اصلی این رویکرد این است که می‌تواند بسیار کند باشد و اغلب غیرضروری است – اگر با استفاده از `-f` سعی نکنید فشار را مجبور کنید، سرور به شما هشدار می‌دهد و فشار را نمی‌پذیرد.
+با این حال، این یک تمرین جالب است و در تئوری می‌تواند به شما کمک کند از یک بازنویسی که ممکن است بعداً مجبور شوید به آن برگردید و آن را اصلاح کنید، اجتناب کنید.


### PR DESCRIPTION
This pull request contains a full Persian translation of the "Git Attributes" section in `book/08-customizing-git/sections/attributes.asc`, making the content accessible to Farsi readers. The translation includes all explanations, code examples, and practical usage scenarios for Git attributes, binary file handling, diffing, keyword expansion, and filters. Additionally, some small updates were made to the project workspace configuration to reflect work on this new section.

**Translation and Documentation Updates:**

* Complete translation of the "Git Attributes" section, including all subsections and code examples, from English to Persian in `book/08-customizing-git/sections/attributes.asc`. This covers explanations of path-specific settings, binary file handling, diffing strategies for non-text files, keyword expansion, and use of clean/smudge filters. [[1]](diffhunk://#diff-db5b5e08b799215b526a3969e7b847d9ae8fb7fa59c5bd28898b14e56e7af2c6L1-R43) [[2]](diffhunk://#diff-db5b5e08b799215b526a3969e7b847d9ae8fb7fa59c5bd28898b14e56e7af2c6L51-R91) [[3]](diffhunk://#diff-db5b5e08b799215b526a3969e7b847d9ae8fb7fa59c5bd28898b14e56e7af2c6L108-R116) [[4]](diffhunk://#diff-db5b5e08b799215b526a3969e7b847d9ae8fb7fa59c5bd28898b14e56e7af2c6L128-R130) [[5]](diffhunk://#diff-db5b5e08b799215b526a3969e7b847d9ae8fb7fa59c5bd28898b14e56e7af2c6L152-R182) [[6]](diffhunk://#diff-db5b5e08b799215b526a3969e7b847d9ae8fb7fa59c5bd28898b14e56e7af2c6L190-R198) [[7]](diffhunk://#diff-db5b5e08b799215b526a3969e7b847d9ae8fb7fa59c5bd28898b14e56e7af2c6L206-R230)

**Workspace and Project Management:**

* Updated `.idea/workspace.xml` to track the new translation work, including changes to recent branches, branch cleanup history, and the default file path for the git widget placeholder. [[1]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL8-R8) [[2]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cR66-R76) [[3]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL79-R94) [[4]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL123-R133) [[5]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cR180-R182)

These changes ensure that the "Git Attributes" documentation is now fully available in Persian, and the project workspace reflects the current focus on the new translation section.