### PR TITLE
translate(10-git-internals): translated environment to persian

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/book/09-git-and-other-scms/sections/client-svn.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/09-git-and-other-scms/sections/client-svn.asc" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/book/10-git-internals/sections/environment.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/10-git-internals/sections/environment.asc" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -86,6 +87,10 @@
               <option name="branches">
                 <list>
                   <RecentBranch>
+                    <option name="branchName" value="book/translation/10-git-internals" />
+                    <option name="lastUsedInstant" value="1757936795" />
+                  </RecentBranch>
+                  <RecentBranch>
                     <option name="branchName" value="book/translation/09-git-and-other-scms" />
                     <option name="lastUsedInstant" value="1757694857" />
                   </RecentBranch>
@@ -130,7 +135,7 @@
     &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;book/translation/09-git-and-other-scms&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;book/translation/10-git-internals&quot;,
     &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
     &quot;last_opened_file_path&quot;: &quot;/Users/mac/Projects/WebstormProjects/Github/progit2-fa&quot;,
     &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
@@ -181,6 +186,7 @@
       <workItem from="1757333632682" duration="1080000" />
       <workItem from="1757343642265" duration="5688000" />
       <workItem from="1757832958644" duration="1276000" />
+      <workItem from="1757942676617" duration="434000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/book/10-git-internals/sections/environment.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/10-git-internals/sections/environment.asc" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/book/10-git-internals/sections/maintenance.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/10-git-internals/sections/maintenance.asc" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -187,6 +186,7 @@
       <workItem from="1757343642265" duration="5688000" />
       <workItem from="1757832958644" duration="1276000" />
       <workItem from="1757942676617" duration="434000" />
+      <workItem from="1758285287928" duration="1055000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/book/10-git-internals/sections/maintenance.asc" beforeDir="false" afterPath="$PROJECT_DIR$/book/10-git-internals/sections/maintenance.asc" afterDir="false" />
-    </list>
+    <list default="true" id="46cbadee-a08d-4f2c-a07d-a3871eab5c16" name="Changes" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -187,6 +185,7 @@
       <workItem from="1757832958644" duration="1276000" />
       <workItem from="1757942676617" duration="434000" />
       <workItem from="1758285287928" duration="1055000" />
+      <workItem from="1758370272526" duration="1720000" />
     </task>
     <servers />
   </component>

--- a/book/10-git-internals/sections/environment.asc
+++ b/book/10-git-internals/sections/environment.asc
@@ -1,131 +1,132 @@
-=== Environment Variables
+=== Environment Variables (متغیرهای محیطی)
 
-Git always runs inside a `bash` shell, and uses a number of shell environment variables to determine how it behaves.
-Occasionally, it comes in handy to know what these are, and how they can be used to make Git behave the way you want it to.
-This isn't an exhaustive list of all the environment variables Git pays attention to, but we'll cover the most useful.
+گیت همیشه داخل یک شل bash اجرا می‌شود و از تعدادی متغیر محیطی شل استفاده می‌کند تا رفتار خود را تعیین کند.
+گاهی اوقات دانستن این متغیرها و اینکه چگونه می‌توان از آن‌ها برای کنترل رفتار گیت استفاده کرد، بسیار مفید است.
+این فهرست شامل تمام متغیرهای محیطی‌ای که گیت به آن‌ها توجه می‌کند نیست، اما ما مفیدترین آن‌ها را بررسی خواهیم کرد.
 
-==== Global Behavior
+==== Global Behavior (رفتار سراسری)
 
-Some of Git's general behavior as a computer program depends on environment variables.
+برخی از رفتارهای کلی گیت به عنوان یک برنامهٔ کامپیوتری، به متغیرهای محیطی وابسته است.
 
-*`GIT_EXEC_PATH`* determines where Git looks for its sub-programs (like `git-commit`, `git-diff`, and others).
-You can check the current setting by running `git --exec-path`.
+*`GIT_EXEC_PATH`* مشخص می‌کند که Git برای یافتن زیر-برنامه‌های خودش (مثل `git-commit`، `git-diff` و سایر ابزارها) کجا را بررسی کند.
+برای مشاهده تنظیم فعلی می‌توانید دستور `git --exec-path` را اجرا کنید.
 
-*`HOME`* isn't usually considered customizable (too many other things depend on it), but it's where Git looks for the global configuration file.
-If you want a truly portable Git installation, complete with global configuration, you can override `HOME` in the portable Git's shell profile.
+*`HOME`* معمولاً قابل شخصی‌سازی در نظر گرفته نمی‌شود (چون بخش‌های زیادی به آن وابسته‌اند)، اما این همان جایی است که Git به دنبال فایل تنظیمات **global** می‌گردد.
+اگر می‌خواهید یک نصب Git کاملاً **قابل حمل (portable)** داشته باشید، به همراه تنظیمات global، می‌توانید مقدار `HOME` را در **shell profile** نسخه‌ی portable Git تغییر دهید.
 
-*`PREFIX`* is similar, but for the system-wide configuration.
-Git looks for this file at `$PREFIX/etc/gitconfig`.
+*`PREFIX`* مشابه است، اما برای تنظیمات **سیستمی** استفاده می‌شود.
+Git این فایل را در مسیر `$PREFIX/etc/gitconfig` جستجو می‌کند.
 
-*`GIT_CONFIG_NOSYSTEM`*, if set, disables the use of the system-wide configuration file.
-This is useful if your system config is interfering with your commands, but you don't have access to change or remove it.
+*`GIT_CONFIG_NOSYSTEM`* اگر تنظیم شود، استفاده از فایل تنظیمات سیستمی را غیرفعال می‌کند.
+این زمانی مفید است که تنظیمات سیستمی باعث تداخل در دستورات شما شوند، اما شما دسترسی به تغییر یا حذف آن‌ها نداشته باشید.
 
-*`GIT_PAGER`* controls the program used to display multi-page output on the command line.
-If this is unset, `PAGER` will be used as a fallback.
+*`GIT_PAGER`* برنامه‌ای را کنترل می‌کند که برای نمایش خروجی چندصفحه‌ای در خط فرمان استفاده می‌شود.
+اگر تنظیم نشده باشد، به عنوان جایگزین از `PAGER` استفاده می‌شود.
 
-*`GIT_EDITOR`* is the editor Git will launch when the user needs to edit some text (a commit message, for example).
-If unset, `EDITOR` will be used.
+*`GIT_EDITOR`* ویرایشگری است که Git در مواقعی که کاربر نیاز به نوشتن یا ویرایش متن دارد (برای مثال یک پیام commit) اجرا می‌کند.
+اگر این مقدار تنظیم نشده باشد، از `EDITOR` استفاده خواهد شد.
 
-==== Repository Locations
+==== Repository Locations (مکان‌های مخزن)
 
-Git uses several environment variables to determine how it interfaces with the current repository.
+گیت از چندین متغیر محیطی استفاده می‌کند تا مشخص کند چگونه با مخزنٔ فعلی تعامل داشته باشد.
 
-*`GIT_DIR`* is the location of the `.git` folder.
-If this isn't specified, Git walks up the directory tree until it gets to `~` or `/`, looking for a `.git` directory at every step.
+*`GIT_DIR`* محل قرارگیری پوشه‌ی `.git` است.
+اگر این مقدار مشخص نشده باشد، Git در درخت دایرکتوری به سمت بالا حرکت می‌کند تا به `~` یا `/` برسد و در هر مرحله به دنبال یک پوشه‌ی `.git` می‌گردد.
 
-*`GIT_CEILING_DIRECTORIES`* controls the behavior of searching for a `.git` directory.
-If you access directories that are slow to load (such as those on a tape drive, or across a slow network connection), you may want to have Git stop trying earlier than it might otherwise, especially if Git is invoked when building your shell prompt.
+*`GIT_CEILING_DIRECTORIES`* رفتار جستجو برای پوشه‌ی `.git` را کنترل می‌کند.
+اگر به دایرکتوری‌هایی دسترسی دارید که بارگذاری آن‌ها کند است (مثل دایرکتوری روی tape drive یا یک اتصال شبکه کند)، می‌توانید کاری کنید که Git زودتر از جستجو دست بکشد، مخصوصاً اگر Git هنگام ساختن **shell prompt** فراخوانی شود.
 
-*`GIT_WORK_TREE`* is the location of the root of the working directory for a non-bare repository.
-If `--git-dir` or `GIT_DIR` is specified but none of `--work-tree`, `GIT_WORK_TREE` or `core.worktree` is specified, the current working directory is regarded as the top level of your working tree.
+*`GIT_WORK_TREE`* محل ریشه‌ی دایرکتوری کاری (working directory) برای یک مخزن غیر-bare است.
+اگر `--git-dir` یا `GIT_DIR` مشخص شده باشد ولی هیچ‌کدام از `--work-tree`، `GIT_WORK_TREE` یا `core.worktree` تنظیم نشده باشند، دایرکتوری کاری فعلی به‌عنوان سطح بالای working tree در نظر گرفته می‌شود.
 
-*`GIT_INDEX_FILE`* is the path to the index file (non-bare repositories only).
+*`GIT_INDEX_FILE`* مسیر فایل ایندکس (فقط در مخازن غیر-bare) را مشخص می‌کند.
 
-*`GIT_OBJECT_DIRECTORY`* can be used to specify the location of the directory that usually resides at `.git/objects`.
+*`GIT_OBJECT_DIRECTORY`* می‌تواند برای تعیین محل دایرکتوری‌ای استفاده شود که معمولاً در `.git/objects` قرار دارد.
 
-*`GIT_ALTERNATE_OBJECT_DIRECTORIES`* is a colon-separated list (formatted like `/dir/one:/dir/two:…`) which tells Git where to check for objects if they aren't in `GIT_OBJECT_DIRECTORY`.
-If you happen to have a lot of projects with large files that have the exact same contents, this can be used to avoid storing too many copies of them.
+*`GIT_ALTERNATE_OBJECT_DIRECTORIES`* یک لیست جدا شده با colon است (مثل `/dir/one:/dir/two:…`) که به Git می‌گوید اگر آبجکت‌ها در `GIT_OBJECT_DIRECTORY` پیدا نشدند، کجا آن‌ها را بررسی کند.
+اگر پروژه‌های زیادی دارید که شامل فایل‌های بزرگ با محتوای یکسان هستند، این متغیر می‌تواند از ذخیره‌سازی چندین نسخه‌ی تکراری جلوگیری کند.
 
-==== Pathspecs
+==== Pathspecs (مسیرهای مشخص)
 
-A "`pathspec`" refers to how you specify paths to things in Git, including the use of wildcards.
-These are used in the `.gitignore` file, but also on the command-line (`git add *.c`).
+"`pathspec`" به نحوهٔ مشخص کردن مسیرها در گیت اشاره دارد، از جمله استفاده از کاراکترهای جایگزین (wildcards).
+این مسیرها در فایل `.gitignore` استفاده می‌شوند، اما همچنین در خط فرمان نیز کاربرد دارند (مثلاً git add *.c).
 
-*`GIT_GLOB_PATHSPECS`* and *`GIT_NOGLOB_PATHSPECS`* control the default behavior of wildcards in pathspecs.
-If `GIT_GLOB_PATHSPECS` is set to 1, wildcard characters act as wildcards (which is the default); if `GIT_NOGLOB_PATHSPECS` is set to 1, wildcard characters only match themselves, meaning something like `\*.c` would only match a file _named_ "`\*.c`", rather than any file whose name ends with `.c`.
-You can override this in individual cases by starting the pathspec with `:(glob)` or `:(literal)`, as in `:(glob)\*.c`.
+*`GIT_GLOB_PATHSPECS`* و *`GIT_NOGLOB_PATHSPECS`* رفتار پیش‌فرض wildcardها را در pathspecها کنترل می‌کنند.
+اگر مقدار `GIT_GLOB_PATHSPECS` برابر 1 باشد، کاراکترهای wildcard به‌صورت wildcard عمل می‌کنند (که حالت پیش‌فرض است).
+اگر مقدار `GIT_NOGLOB_PATHSPECS` برابر 1 باشد، کاراکترهای wildcard فقط خودشـان را match می‌کنند؛ یعنی چیزی مثل `\*.c` فقط فایلی با نام دقیق "`\*.c`" را match می‌کند، نه هر فایلی که پسوند `.c` دارد.
+می‌توانید این رفتار را در موارد خاص با پیشوند `:(glob)` یا `:(literal)` تغییر دهید؛ مثلاً: `:(glob)\*.c`.
 
-*`GIT_LITERAL_PATHSPECS`* disables both of the above behaviors; no wildcard characters will work, and the override prefixes are disabled as well.
+*`GIT_LITERAL_PATHSPECS`* هر دو رفتار بالا را غیرفعال می‌کند؛ هیچ کاراکتر wildcardی کار نخواهد کرد و پیشوندهای override هم غیرفعال می‌شوند.
 
-*`GIT_ICASE_PATHSPECS`* sets all pathspecs to work in a case-insensitive manner.
+*`GIT_ICASE_PATHSPECS`* باعث می‌شود همه‌ی pathspecها به‌صورت **case-insensitive** عمل کنند.
 
-==== Committing
+==== Committing (کامیت کردن)
 
-The final creation of a Git commit object is usually done by `git-commit-tree`, which uses these environment variables as its primary source of information, falling back to configuration values only if these aren't present.
+ایجاد نهایی یک شیء کامیت در گیت معمولاً توسط `git-commit-tree` انجام می‌شود، که این متغیرهای محیطی را به‌عنوان منبع اصلی اطلاعات خود استفاده می‌کند و تنها در صورتی به مقادیر تنظیمات پیکربندی رجوع می‌کند که این متغیرها موجود نباشند.
 
-*`GIT_AUTHOR_NAME`* is the human-readable name in the "`author`" field.
+*`GIT_AUTHOR_NAME`* نام قابل‌خواندن (human-readable) برای فیلد "`author`" است.
 
-*`GIT_AUTHOR_EMAIL`* is the email for the "`author`" field.
+*`GIT_AUTHOR_EMAIL`* ایمیل مربوط به فیلد "`author`" است.
 
-*`GIT_AUTHOR_DATE`* is the timestamp used for the "`author`" field.
+*`GIT_AUTHOR_DATE`* زمان (timestamp) استفاده‌شده در فیلد "`author`" است.
 
-*`GIT_COMMITTER_NAME`* sets the human name for the "`committer`" field.
+*`GIT_COMMITTER_NAME`* نام قابل‌خواندن (human name) برای فیلد "`committer`" را تنظیم می‌کند.
 
-*`GIT_COMMITTER_EMAIL`* is the email address for the "`committer`" field.
+*`GIT_COMMITTER_EMAIL`* ایمیل مربوط به فیلد "`committer`" است.
 
-*`GIT_COMMITTER_DATE`* is used for the timestamp in the "`committer`" field.
+*`GIT_COMMITTER_DATE`* برای زمان (timestamp) در فیلد "`committer`" استفاده می‌شود.
 
-*`EMAIL`* is the fallback email address in case the `user.email` configuration value isn't set.
-If _this_ isn't set, Git falls back to the system user and host names.
+*`EMAIL`* ایمیل جایگزین (fallback) است در صورتی که مقدار `user.email` در تنظیمات مشخص نشده باشد.
+اگر این هم تنظیم نشده باشد، Git از نام کاربر و نام میزبان (system user و host names) استفاده می‌کند.
 
-==== Networking
+==== Networking (شبکه)
 
-Git uses the `curl` library to do network operations over HTTP, so *`GIT_CURL_VERBOSE`* tells Git to emit all the messages generated by that library.
-This is similar to doing `curl -v` on the command line.
+گیت برای انجام عملیات شبکه‌ای از طریق HTTP از کتابخانهٔ `curl` استفاده می‌کند، بنابراین *`GIT_CURL_VERBOSE`* به گیت می‌گوید تمام پیام‌هایی که توسط آن کتابخانه تولید می‌شوند را نمایش دهد.
+این مشابه اجرای `curl -`v در خط فرمان است.
 
-*`GIT_SSL_NO_VERIFY`* tells Git not to verify SSL certificates.
-This can sometimes be necessary if you're using a self-signed certificate to serve Git repositories over HTTPS, or you're in the middle of setting up a Git server but haven't installed a full certificate yet.
+*`GIT_SSL_NO_VERIFY`* به Git می‌گوید که گواهی‌های SSL را بررسی نکند.
+این مورد گاهی ضروری است، مثلاً زمانی که از یک گواهی **self-signed** برای ارائه‌ی مخزن‌های Git از طریق HTTPS استفاده می‌کنید، یا وقتی در حال راه‌اندازی یک سرور Git هستید اما هنوز گواهی کامل نصب نشده است.
 
-If the data rate of an HTTP operation is lower than *`GIT_HTTP_LOW_SPEED_LIMIT`* bytes per second for longer than *`GIT_HTTP_LOW_SPEED_TIME`* seconds, Git will abort that operation.
-These values override the `http.lowSpeedLimit` and `http.lowSpeedTime` configuration values.
+اگر نرخ انتقال داده در یک عملیات HTTP کمتر از *`GIT_HTTP_LOW_SPEED_LIMIT`* بایت بر ثانیه باشد و این وضعیت بیشتر از *`GIT_HTTP_LOW_SPEED_TIME`* ثانیه ادامه پیدا کند، Git آن عملیات را متوقف می‌کند.
+این مقادیر، مقادیر تنظیمات `http.lowSpeedLimit` و `http.lowSpeedTime` را override می‌کنند.
 
-*`GIT_HTTP_USER_AGENT`* sets the user-agent string used by Git when communicating over HTTP.
-The default is a value like `git/2.0.0`.
+*`GIT_HTTP_USER_AGENT`* رشته‌ی user-agent را تنظیم می‌کند که Git هنگام برقراری ارتباط از طریق HTTP استفاده می‌کند.
+مقدار پیش‌فرض چیزی شبیه به `git/2.0.0` است.
 
-==== Diffing and Merging
+==== Diffing and Merging (مقایسه و ادغام)
 
-*`GIT_DIFF_OPTS`* is a bit of a misnomer.
-The only valid values are `-u<n>` or `--unified=<n>`, which controls the number of context lines shown in a `git diff` command.
+*`GIT_DIFF_OPTS`* یک نام‌گذاری نه‌چندان دقیق (misnomer) است.
+تنها مقادیر معتبر `-u<n>` یا `--unified=<n>` هستند که تعداد خطوط context را در دستور `git diff` مشخص می‌کنند.
 
-*`GIT_EXTERNAL_DIFF`* is used as an override for the `diff.external` configuration value.
-If it's set, Git will invoke this program when `git diff` is invoked.
+*`GIT_EXTERNAL_DIFF`* برای override کردن مقدار تنظیمات `diff.external` استفاده می‌شود.
+اگر تنظیم شود، Git هنگام اجرای `git diff` این برنامه را اجرا خواهد کرد.
 
-*`GIT_DIFF_PATH_COUNTER`* and *`GIT_DIFF_PATH_TOTAL`* are useful from inside the program specified by `GIT_EXTERNAL_DIFF` or `diff.external`.
-The former represents which file in a series is being diffed (starting with 1), and the latter is the total number of files in the batch.
+*`GIT_DIFF_PATH_COUNTER`* و *`GIT_DIFF_PATH_TOTAL`* از داخل برنامه‌ای که توسط `GIT_EXTERNAL_DIFF` یا `diff.external` مشخص شده، کاربرد دارند.
+اولی نشان‌دهنده‌ی این است که کدام فایل در یک سری در حال diff شدن است (شروع از 1)، و دومی تعداد کل فایل‌ها در آن batch را مشخص می‌کند.
 
-*`GIT_MERGE_VERBOSITY`* controls the output for the recursive merge strategy.
-The allowed values are as follows:
+*`GIT_MERGE_VERBOSITY`* خروجی مربوط به **recursive merge strategy** را کنترل می‌کند.
+مقادیر مجاز به شکل زیر هستند:
 
-* 0 outputs nothing, except possibly a single error message.
-* 1 shows only conflicts.
-* 2 also shows file changes.
-* 3 shows when files are skipped because they haven't changed.
-* 4 shows all paths as they are processed.
-* 5 and above show detailed debugging information.
+- `0` هیچ خروجی‌ای ندارد (به‌جز احتمالاً یک پیام خطا).
+- `1` فقط conflictها را نشان می‌دهد.
+- `2` تغییرات فایل‌ها را هم نشان می‌دهد.
+- `3` نشان می‌دهد چه فایل‌هایی به‌دلیل عدم تغییر رد (skip) شدند.
+- `4` همه‌ی مسیرها (paths) را هنگام پردازش نشان می‌دهد.
+- `5` و بالاتر، اطلاعات کامل **debugging** را نمایش می‌دهند.
 
-The default value is 2.
+مقدار پیش‌فرض برابر با `2` است.
 
-==== Debugging
+==== Debugging (دیباگ کردن)
 
-Want to _really_ know what Git is up to?
-Git has a fairly complete set of traces embedded, and all you need to do is turn them on.
-The possible values of these variables are as follows:
+می‌خواهید واقعاً بدانید گیت چه کار می‌کند؟
+گیت مجموعه‌ای نسبتاً کامل از ردیابی‌ها (traces) را در خود دارد و تنها کاری که باید انجام دهید، فعال کردن آن‌هاست.
+مقادیر ممکن برای این متغیرها به شرح زیر هستند:
 
-* "`true`", "`1`", or "`2`" – the trace category is written to stderr.
-* An absolute path starting with `/` – the trace output will be written to that file.
+* "`true`"، "`1`" یا "`2`" → خروجی trace به **stderr** نوشته می‌شود.
+* یک مسیر مطلق که با `/` شروع شود → خروجی trace در آن فایل نوشته خواهد شد.
 
-*`GIT_TRACE`* controls general traces, which don't fit into any specific category.
-This includes the expansion of aliases, and delegation to other sub-programs.
+*`GIT_TRACE`* ردیابی‌های عمومی (general traces) را کنترل می‌کند، یعنی مواردی که در هیچ دسته‌بندی خاصی قرار نمی‌گیرند.
+این شامل گسترش **aliasها** و واگذاری (delegation) به زیر‌برنامه‌های دیگر می‌شود.
 
 [source,console]
 ----
@@ -138,8 +139,8 @@ $ GIT_TRACE=true git lga
 20:12:49.899675 run-command.c:192       trace: exec: 'less'
 ----
 
-*`GIT_TRACE_PACK_ACCESS`* controls tracing of packfile access.
-The first field is the packfile being accessed, the second is the offset within that file:
+*`GIT_TRACE_PACK_ACCESS`* ردیابی مربوط به دسترسی به **packfile**‌ها را کنترل می‌کند.
+فیلد اول نام packfile در حال دسترسی است و فیلد دوم offset درون آن فایل را نشان می‌دهد.
 
 [source,console]
 ----
@@ -155,7 +156,7 @@ Your branch is up-to-date with 'origin/master'.
 nothing to commit, working directory clean
 ----
 
-*`GIT_TRACE_PACKET`* enables packet-level tracing for network operations.
+*`GIT_TRACE_PACKET`* ردیابی در سطح **packet** برای عملیات‌های شبکه را فعال می‌کند.
 
 [source,console]
 ----
@@ -168,8 +169,8 @@ $ GIT_TRACE_PACKET=true git ls-remote origin
 # […]
 ----
 
-*`GIT_TRACE_PERFORMANCE`* controls logging of performance data.
-The output shows how long each particular `git` invocation takes.
+*`GIT_TRACE_PERFORMANCE`* لاگ‌گیری مربوط به داده‌های **performance** را کنترل می‌کند.
+خروجی نشان می‌دهد که هر بار اجرای یک دستور `git` چقدر زمان برده است.
 
 [source,console]
 ----
@@ -191,7 +192,7 @@ Checking connectivity: 170994, done.
 20:18:25.233159 trace.c:414             performance: 6.112217000 s: git command: 'git' 'gc'
 ----
 
-*`GIT_TRACE_SETUP`* shows information about what Git is discovering about the repository and environment it's interacting with.
+*`GIT_TRACE_SETUP`* اطلاعاتی درباره‌ی کشف (discovery) Git از مخزن و محیطی که با آن در تعامل است نشان می‌دهد.
 
 [source,console]
 ----
@@ -205,28 +206,30 @@ Your branch is up-to-date with 'origin/master'.
 nothing to commit, working directory clean
 ----
 
-==== Miscellaneous
+==== Miscellaneous (متفرقه)
 
-*`GIT_SSH`*, if specified, is a program that is invoked instead of `ssh` when Git tries to connect to an SSH host.
-It is invoked like `$GIT_SSH [username@]host [-p <port>] <command>`.
-Note that this isn't the easiest way to customize how `ssh` is invoked; it won't support extra command-line parameters.
-To support extra command-line parameters, you can use *`GIT_SSH_COMMAND`*, write a wrapper script and set `GIT_SSH` to point to it or use the `~/.ssh/config` file.
+*`GIT_SSH`*، در صورتی که مشخص شود، برنامه‌ای است که به جای `ssh` فراخوانی می‌شود وقتی Git سعی می‌کند به یک هاست SSH متصل شود.
+این برنامه به شکل زیر فراخوانی می‌شود:
+`$GIT_SSH [username@]host [-p <port>] <command>`.
+توجه داشته باشید که این روش ساده‌ترین راه برای شخصی‌سازی نحوه فراخوانی `ssh` نیست؛ این روش از پارامترهای اضافی خط فرمان پشتیبانی نمی‌کند.
+برای پشتیبانی از پارامترهای اضافی خط فرمان، می‌توانید از *`GIT_SSH_COMMAND`* استفاده کنید، یک اسکریپت wrapper بنویسید و `GIT_SSH` را به آن اشاره دهید یا از فایل `~/.ssh/config` استفاده کنید.
 
-*`GIT_SSH_COMMAND`* sets the SSH command used when Git tries to connect to an SSH host.
-The command is interpreted by the shell, and extra command-line arguments can be used with `ssh`, such as `GIT_SSH_COMMAND="ssh -i ~/.ssh/my_key" git clone git@example.com:my/repo`.
+*`GIT_SSH_COMMAND`* فرمان SSH مورد استفاده هنگام تلاش Git برای اتصال به یک هاست SSH را تنظیم می‌کند.
+این فرمان توسط shell تفسیر می‌شود و می‌توان پارامترهای اضافی خط فرمان را به `ssh` داد، مانند:
+GIT_SSH_COMMAND="ssh -i ~/.ssh/my_key" git clone git@example.com:my/repo
 
-*`GIT_ASKPASS`* is an override for the `core.askpass` configuration value.
-This is the program invoked whenever Git needs to ask the user for credentials, which can expect a text prompt as a command-line argument, and should return the answer on `stdout` (see <<ch07-git-tools#_credential_caching>> for more on this subsystem).
+*`GIT_ASKPASS`* جایگزینی برای مقدار تنظیمات `core.askpass` است.
+این برنامه هر بار که Git نیاز به درخواست اطلاعات کاربری از کاربر دارد فراخوانی می‌شود، و می‌تواند یک متن prompt را به عنوان آرگومان خط فرمان دریافت کند و پاسخ را در `stdout` برگرداند (برای اطلاعات بیشتر در مورد این زیرسیستم، ببینید <<ch07-git-tools#_credential_caching>>).
 
-*`GIT_NAMESPACE`* controls access to namespaced refs, and is equivalent to the `--namespace` flag.
-This is mostly useful on the server side, where you may want to store multiple forks of a single repository in one repository, only keeping the refs separate.
+*`GIT_NAMESPACE`* دسترسی به refs دارای namespace را کنترل می‌کند و معادل گزینه `--namespace` است.
+این مورد عمدتاً در سمت سرور کاربرد دارد، جایی که ممکن است بخواهید چندین fork از یک مخزن را در یک مخزن نگه دارید و تنها refs آنها را جدا نگه دارید.
 
-*`GIT_FLUSH`* can be used to force Git to use non-buffered I/O when writing incrementally to stdout.
-A value of 1 causes Git to flush more often, a value of 0 causes all output to be buffered.
-The default value (if this variable is not set) is to choose an appropriate buffering scheme depending on the activity and the output mode.
+*`GIT_FLUSH`* می‌تواند برای اجبار Git به استفاده از I/O بدون بافر هنگام نوشتن تدریجی به stdout استفاده شود.
+مقدار 1 باعث می‌شود Git بیشتر flush کند، مقدار 0 باعث می‌شود تمام خروجی بافر شود.
+مقدار پیش‌فرض (اگر این متغیر تنظیم نشده باشد) انتخاب یک روش بافر مناسب بسته به فعالیت و حالت خروجی است.
 
-*`GIT_REFLOG_ACTION`* lets you specify the descriptive text written to the reflog.
-Here's an example:
+*`GIT_REFLOG_ACTION`* به شما امکان می‌دهد متن توضیحی که در reflog نوشته می‌شود را مشخص کنید.
+مثالی از آن:
 
 [source,console]
 ----

--- a/book/10-git-internals/sections/maintenance.asc
+++ b/book/10-git-internals/sections/maintenance.asc
@@ -1,29 +1,23 @@
-=== Maintenance and Data Recovery
+=== Maintenance and Data Recovery (نگهداری و بازیابی داده‌ها)
 
-Occasionally, you may have to do some cleanup – make a repository more compact, clean up an imported repository, or recover lost work.
-This section will cover some of these scenarios.
+گاهی اوقات لازم است کمی پاک‌سازی انجام دهید — مثلاً مخزنی را فشرده‌تر کنید، یک مخزن وارد شده را مرتب کنید یا کار از دست‌رفته‌ای را بازیابی کنید. این بخش به برخی از این سناریوها می‌پردازد.
 
 [[_git_gc]]
-==== Maintenance
+==== Maintenance (نگهداری)
 
-Occasionally, Git automatically runs a command called "`auto gc`".
-Most of the time, this command does nothing.
-However, if there are too many loose objects (objects not in a packfile) or too many packfiles, Git launches a full-fledged `git gc` command.
-The "`gc`" stands for garbage collect, and the command does a number of things: it gathers up all the loose objects and places them in packfiles, it consolidates packfiles into one big packfile, and it removes objects that aren't reachable from any commit and are a few months old.
 
-You can run `auto gc` manually as follows:
+گاهی Git به‌طور خودکار فرمانی به نام "auto gc" را اجرا می‌کند. در بیشتر مواقع این فرمان کاری انجام نمی‌دهد. با این حال، اگر شیءهای جدا (شیءهایی که در یک packfile نیستند) زیاد شوند یا تعداد packfileها بیش از حد شود، Git یک فرمان کامل `git gc` را اجرا می‌کند. "gc" مخفف garbage collect است و این فرمان چند کار انجام می‌دهد: همهٔ شیءهای جدا را جمع‌آوری کرده و در packfileها قرار می‌دهد، packfileها را در یک packfile بزرگ‌تر تجمیع می‌کند، و اشیائی را که از هیچ commitی قابل دسترسی نیستند و چند ماهه شده‌اند حذف می‌کند.
+
+می‌توانید به‌صورت دستی `auto gc` را این‌گونه اجرا کنید:
 
 [source,console]
 ----
 $ git gc --auto
 ----
 
-Again, this generally does nothing.
-You must have around 7,000 loose objects or more than 50 packfiles for Git to fire up a real `gc` command.
-You can modify these limits with the `gc.auto` and `gc.autopacklimit` config settings, respectively.
+باز هم، معمولاً این کار فایده‌ای ندارد. برای اینکه Git واقعا فرمان `gc` را اجرا کند باید در حدود ۷۰۰۰ شیء جدا یا بیشتر یا بیش از ۵۰ packfile داشته باشید. می‌توانید این محدودیت‌ها را به‌ترتیب با تنظیمات پیکربندی `gc.auto` و `gc.autopacklimit` تغییر دهید.
 
-The other thing `gc` will do is pack up your references into a single file.
-Suppose your repository contains the following branches and tags:
+کار دیگری که `gc` انجام می‌دهد این است که مراجع شما را در یک فایل واحد بسته‌بندی می‌کند. فرض کنید مخزن شما شامل شاخه‌ها و برچسب‌های زیر باشد:
 
 [source,console]
 ----
@@ -34,8 +28,7 @@ $ find .git/refs -type f
 .git/refs/tags/v1.1
 ----
 
-If you run `git gc`, you'll no longer have these files in the `refs` directory.
-Git will move them for the sake of efficiency into a file named `.git/packed-refs` that looks like this:
+اگر `git gc` را اجرا کنید، دیگر این فایل‌ها را در دایرکتوری `refs` نخواهید دید. Git برای کارایی آنها را به فایلی به‌نام `.git/packed-refs` منتقل می‌کند که شبیه به این است:
 
 [source,console]
 ----
@@ -48,22 +41,19 @@ cac0cab538b970a37ea1e769cbbde608743bc96d refs/tags/v1.0
 ^1a410efbd13591db07496601ebc7a059dd55cfe9
 ----
 
-If you update a reference, Git doesn't edit this file but instead writes a new file to `refs/heads`.
-To get the appropriate SHA-1 for a given reference, Git checks for that reference in the `refs` directory and then checks the `packed-refs` file as a fallback.
-So if you can't find a reference in the `refs` directory, it's probably in your `packed-refs` file.
+اگر یک مرجع را به‌روز کنید، Git این فایل را ویرایش نمی‌کند بلکه به‌جای آن یک فایل جدید در `refs/heads` می‌نویسد. برای به‌دست آوردن SHA-1 مناسب یک مرجع، Git ابتدا آن مرجع را در دایرکتوری `refs` جست‌وجو می‌کند و سپس در صورت عدم یافتن، به‌عنوان پشتیبان فایل `packed-refs` را بررسی می‌کند. پس اگر نتوانستید مرجعی را در دایرکتوری `refs` پیدا کنید، احتمالاً در فایل `packed-refs` شما قرار دارد.
 
-Notice the last line of the file, which begins with a `^`.
-This means the tag directly above is an annotated tag and that line is the commit that the annotated tag points to.
+به خط آخر فایل که با `^` شروع می‌شود دقت کنید. این یعنی تگ بالای آن یک annotated tag است و آن خط اشاره به commitای دارد که آن annotated tag به آن اشاره می‌کند.
 
 [[_data_recovery]]
-==== Data Recovery
+==== Data Recovery (بازیابی داده‌ها)
 
-At some point in your Git journey, you may accidentally lose a commit.
-Generally, this happens because you force-delete a branch that had work on it, and it turns out you wanted the branch after all; or you hard-reset a branch, thus abandoning commits that you wanted something from.
-Assuming this happens, how can you get your commits back?
+در مقطعی از مسیر یادگیری Git ممکن است به‌طور تصادفی یک commit را از دست بدهید.
+معمولاً این اتفاق وقتی رخ می‌دهد که یک شاخه را با force حذف می‌کنید در حالی که روی آن کار داشته‌اید و بعداً متوجه می‌شوید که به آن شاخه نیاز داشته‌اید؛ یا وقتی که یک شاخه را با hard reset به عقب برمی‌گردانید و به‌این‌ترتیب commitهایی را رها می‌کنید که از بعضیِ آن‌ها چیزی لازم داشتید.
+اگر چنین وضعیتی پیش بیاید، چگونه می‌توانید commitهای از دست رفته را بازیابی کنید؟
 
-Here's an example that hard-resets the `master` branch in your test repository to an older commit and then recovers the lost commits.
-First, let's review where your repository is at this point:
+در اینجا یک مثال نشان داده شده که شاخه master را در مخزن تست شما به یک commit قدیمی‌تر hard-reset می‌کند و سپس commitهای از دست رفته را بازیابی می‌نماید.
+ابتدا بیایید مروری بر وضعیت فعلی مخزن داشته باشیم:
 
 [source,console]
 ----
@@ -75,7 +65,7 @@ cac0cab538b970a37ea1e769cbbde608743bc96d Second commit
 fdf4fc3344e67ab068f836878b6c4951e3b15f3d First commit
 ----
 
-Now, move the `master` branch back to the middle commit:
+اکنون شاخه master را به commit میانی برگردانید:
 
 [source,console]
 ----
@@ -87,15 +77,15 @@ cac0cab538b970a37ea1e769cbbde608743bc96d Second commit
 fdf4fc3344e67ab068f836878b6c4951e3b15f3d First commit
 ----
 
-You've effectively lost the top two commits – you have no branch from which those commits are reachable.
-You need to find the latest commit SHA-1 and then add a branch that points to it.
-The trick is finding that latest commit SHA-1 – it's not like you've memorized it, right?
+به‌این‌ترتیب عملاً دو commit بالایی را از دست داده‌اید — هیچ شاخه‌ای وجود ندارد که آن commitها از طریق آن قابل دسترسی باشند.
+شما باید آخرین شناسه SHA-1 commit را پیدا کنید و سپس شاخه‌ای بسازید که به آن اشاره کند.
+نکته کار پیدا کردن آخرین SHA-1 است — قطعاً آن را حفظ نکرده‌اید، درست است؟
 
-Often, the quickest way is to use a tool called `git reflog`.
-As you're working, Git silently records what your HEAD is every time you change it.
-Each time you commit or change branches, the reflog is updated.
-The reflog is also updated by the `git update-ref` command, which is another reason to use it instead of just writing the SHA-1 value to your ref files, as we covered in <<ch10-git-internals#_git_refs>>.
-You can see where you've been at any time by running `git reflog`:
+اغلب سریع‌ترین راه استفاده از ابزاری به نام git reflog است.
+زمانی که کار می‌کنید، Git بی‌صدا هر بار که HEAD را تغییر می‌دهید، وضعیت آن را ثبت می‌کند.
+هر بار که commit می‌زنید یا شاخه را تغییر می‌دهید، reflog به‌روزرسانی می‌شود.
+دستور git update-ref نیز reflog را به‌روزرسانی می‌کند، که این خود دلیل دیگری است برای استفاده از reflog به‌جای نوشتن مستقیم مقدار SHA-1 در فایل‌های ref که در <<ch10-git-internals#_git_refs>> مورد بحث قرار گرفت.
+هر زمان می‌خواهید می‌توانید با اجرای git reflog ببینید قبلاً کجا بوده‌اید:
 
 [source,console]
 ----
@@ -105,8 +95,8 @@ ab1afef HEAD@{1}: commit: Modify repo.rb a bit
 484a592 HEAD@{2}: commit: Create repo.rb
 ----
 
-Here we can see the two commits that we have had checked out, however there is not much information here.
-To see the same information in a much more useful way, we can run `git log -g`, which will give you a normal log output for your reflog.
+در اینجا می‌توانیم دو commit را که قبلاً چک‌اوت شده‌اند ببینیم، اما اطلاعات زیادی نمایش داده نشده است.
+برای دیدن همان اطلاعات به شکلی بسیار مفیدتر، می‌توانید git log -g را اجرا کنید که خروجی معمولی log را برای reflog به شما می‌دهد.
 
 [source,console]
 ----
@@ -128,8 +118,8 @@ Date:   Fri May 22 18:15:24 2009 -0700
        Modify repo.rb a bit
 ----
 
-It looks like the bottom commit is the one you lost, so you can recover it by creating a new branch at that commit.
-For example, you can start a branch named `recover-branch` at that commit (ab1afef):
+به نظر می‌رسد commit پایینی همانی است که از دست داده‌اید، پس می‌توانید با ساختن یک شاخه جدید روی آن، آن را بازیابی کنید.
+برای مثال، می‌توانید شاخه‌ای به نام recover-branch را از آن commit (ab1afef) شروع کنید:
 
 [source,console]
 ----
@@ -142,9 +132,9 @@ cac0cab538b970a37ea1e769cbbde608743bc96d Second commit
 fdf4fc3344e67ab068f836878b6c4951e3b15f3d First commit
 ----
 
-Cool – now you have a branch named `recover-branch` that is where your `master` branch used to be, making the first two commits reachable again.
-Next, suppose your loss was for some reason not in the reflog – you can simulate that by removing `recover-branch` and deleting the reflog.
-Now the first two commits aren't reachable by anything:
+ خوب — حالا یک شاخه به نام `recover-branch` داری که همان جایی است که شاخهٔ `master` قبلاً قرار داشت و دو کمیت اول دوباره قابل دسترسی شده‌اند.
+حالا فرض کن به دلایلی آن داده در reflog نبوده — می‌توانی این را با حذف `recover-branch` و پاک کردن reflog شبیه‌سازی کنی.
+در این صورت دو کمیت اول دیگر توسط هیچ چیزی قابل دسترسی نیستند:
 
 [source,console]
 ----
@@ -152,10 +142,10 @@ $ git branch -D recover-branch
 $ rm -Rf .git/logs/
 ----
 
-Because the reflog data is kept in the `.git/logs/` directory, you effectively have no reflog.
-How can you recover that commit at this point?
-One way is to use the `git fsck` utility, which checks your database for integrity.
-If you run it with the `--full` option, it shows you all objects that aren't pointed to by another object:
+از آنجا که داده‌های reflog در پوشهٔ `.git/logs/` نگهداری می‌شوند، عملاً reflog ندارید.
+در این مرحله چگونه می‌توانی آن کمیت را بازیابی کنی؟
+یکی از روش‌ها استفاده از ابزار `git fsck` است که دیتابیس را از نظر یکپارچگی بررسی می‌کند.
+اگر آن را با گزینهٔ `--full` اجرا کنی، همهٔ اشیائی را نشان می‌دهد که توسط هیچ شیء دیگری اشاره نشده‌اند:
 
 [source,console]
 ----
@@ -168,27 +158,28 @@ dangling tree aea790b9a58f6cf6f2804eeac9f0abbe9631e4c9
 dangling blob 7108f7ecb345ee9d0084193f147cdad4d2998293
 ----
 
-In this case, you can see your missing commit after the string "`dangling commit`".
-You can recover it the same way, by adding a branch that points to that SHA-1.
+در این مثال می‌توانی کمیت گمشده‌ات را بعد از عبارت "`dangling commit`" ببینی.
+می‌توانی آن را همان‌طور بازیابی کنی: با اضافه کردن یک شاخه که به آن SHA-1 اشاره کند.
 
 [[_removing_objects]]
-==== Removing Objects
+==== Removing Objects (حذف اشیاء)
 
-There are a lot of great things about Git, but one feature that can cause issues is the fact that a `git clone` downloads the entire history of the project, including every version of every file.
-This is fine if the whole thing is source code, because Git is highly optimized to compress that data efficiently.
-However, if someone at any point in the history of your project added a single huge file, every clone for all time will be forced to download that large file, even if it was removed from the project in the very next commit.
-Because it's reachable from the history, it will always be there.
+دربارهٔ گیت چیزهای خوب زیادی هست، اما یک ویژگی که می‌تواند مشکل‌ساز شود این است که یک `git clone` تمام تاریخچهٔ پروژه را دانلود می‌کند، از جمله هر نسخه از هر فایل.
+این مسئله وقتی کد منبع خالص است مشکل چندانی ایجاد نمی‌کند، زیرا گیت در فشرده‌سازی این داده‌ها بسیار بهینه است.
+با این حال، اگر در هر نقطه‌ای از تاریخچهٔ پروژه کسی یک فایل بسیار حجیم اضافه کرده باشد، تمام کلون‌های بعدی برای همیشه مجبور به دانلود آن فایل بزرگ خواهند بود، حتی اگر در کمیت بعدی از پروژه حذف شده باشد.
+از آنجا که آن فایل از تاریخچه قابل دسترسی است، همیشه آنجا خواهد ماند.
 
-This can be a huge problem when you're converting Subversion or Perforce repositories into Git.
-Because you don't download the whole history in those systems, this type of addition carries few consequences.
-If you did an import from another system or otherwise find that your repository is much larger than it should be, here is how you can find and remove large objects.
+این می‌تواند هنگام تبدیل مخازن Subversion یا Perforce به گیت مشکل بزرگی ایجاد کند.
+چون در آن سیستم‌ها تمام تاریخچه را دانلود نمی‌کنید، این نوع اضافه‌کردن تبعات کمی دارد.
+اگر از یک سیستم دیگر ایمپورت کرده‌ای یا به هر دلیلی متوجه شده‌ای که مخزن‌ات بسیار بزرگ‌تر از حد انتظار است، این‌جا روش یافتن و حذف اشیاء بزرگ را می‌بینی.
 
-*Be warned: this technique is destructive to your commit history.*
-It rewrites every commit object since the earliest tree you have to modify to remove a large file reference.
-If you do this immediately after an import, before anyone has started to base work on the commit, you're fine – otherwise, you have to notify all contributors that they must rebase their work onto your new commits.
+*هشدار: این تکنیک برای commit history مخرب است.*
+این روش باعث می‌شود تمام commit objectها از اولین tree‌ای که باید برای حذف یک فایل بزرگ تغییر داده شود، بازنویسی شوند.
+اگر این کار را **بلافاصله بعد از import** انجام دهید، قبل از اینکه کسی شروع به base کردن کار خود روی commit کند، مشکلی نیست – در غیر این صورت، باید به تمام contributors اطلاع دهید که آن‌ها باید کارشان را روی commits جدید شما rebase کنند.
 
-To demonstrate, you'll add a large file into your test repository, remove it in the next commit, find it, and remove it permanently from the repository.
-First, add a large object to your history:
+برای نشان دادن این موضوع، شما یک فایل بزرگ را به test repository خود اضافه می‌کنید، در commit بعدی آن را حذف می‌کنید، آن را پیدا می‌کنید و سپس به طور دائمی از repository حذف می‌کنید.
+
+ابتدا، یک object بزرگ به history خود اضافه کنید:
 
 [source,console]
 ----
@@ -200,8 +191,8 @@ $ git commit -m 'Add git tarball'
  create mode 100644 git.tgz
 ----
 
-Oops – you didn't want to add a huge tarball to your project.
-Better get rid of it:
+اوه – شما نمی‌خواستید یک tarball حجیم به پروژه اضافه کنید.
+بهتر است از شر آن خلاص شوید:
 
 [source,console]
 ----
@@ -213,7 +204,7 @@ $ git commit -m 'Oops - remove large tarball'
  delete mode 100644 git.tgz
 ----
 
-Now, `gc` your database and see how much space you're using:
+حالا، روی دیتابیس خود `gc` اجرا کنید و ببینید چه مقدار فضا استفاده کرده‌اید:
 
 [source,console]
 ----
@@ -225,7 +216,7 @@ Writing objects: 100% (17/17), done.
 Total 17 (delta 1), reused 10 (delta 0)
 ----
 
-You can run the `count-objects` command to quickly see how much space you're using:
+می‌توانید دستور `count-objects` را اجرا کنید تا سریع ببینید چه مقدار فضا در حال استفاده است:
 
 [source,console]
 ----
@@ -240,16 +231,16 @@ garbage: 0
 size-garbage: 0
 ----
 
-The `size-pack` entry is the size of your packfiles in kilobytes, so you're using almost 5MB.
-Before the last commit, you were using closer to 2K – clearly, removing the file from the previous commit didn't remove it from your history.
-Every time anyone clones this repository, they will have to clone all 5MB just to get this tiny project, because you accidentally added a big file.
-Let's get rid of it.
+ورودی `size-pack` اندازه‌ی packfileهای شما را برحسب kilobyte نشان می‌دهد، پس شما تقریباً ۵MB استفاده کرده‌اید.
+قبل از آخرین commit، شما چیزی نزدیک به 2K استفاده می‌کردید – مشخص است که حذف فایل از commit قبلی آن را از history حذف نکرد.
+هر بار که کسی این repository را clone کند، باید کل ۵MB را clone کند فقط برای گرفتن این پروژه‌ی کوچک، چون شما به اشتباه یک فایل بزرگ اضافه کرده‌اید.
+بیایید از شرش خلاص شویم.
 
-First you have to find it.
-In this case, you already know what file it is.
-But suppose you didn't; how would you identify what file or files were taking up so much space?
-If you run `git gc`, all the objects are in a packfile; you can identify the big objects by running another plumbing command called `git verify-pack` and sorting on the third field in the output, which is file size.
-You can also pipe it through the `tail` command because you're only interested in the last few largest files:
+ابتدا باید آن را پیدا کنید.
+در این مورد، شما می‌دانید آن فایل چیست.
+اما فرض کنید نمی‌دانستید؛ چطور می‌توانستید تشخیص دهید چه فایل یا فایل‌هایی این‌قدر فضا اشغال کرده‌اند؟
+اگر `git gc` اجرا کنید، همه‌ی objectها داخل یک packfile قرار می‌گیرند؛ می‌توانید objectهای بزرگ را با اجرای دستور plumbing دیگری به نام `git verify-pack` شناسایی کنید و روی فیلد سوم خروجی (یعنی اندازه فایل) sort کنید.
+همچنین می‌توانید خروجی را با دستور `tail` فیلتر کنید چون فقط به چند فایل بزرگ آخر علاقه دارید:
 
 [source,console]
 ----
@@ -261,10 +252,10 @@ dadf7258d699da2c8d89b09ef6670edb7d5f91b4 commit 229 159 12
 82c99a3e86bb1267b236a4b6eff7868d97489af1 blob   4975916 4976258 1438
 ----
 
-The big object is at the bottom: 5MB.
-To find out what file it is, you'll use the `rev-list` command, which you used briefly in <<ch08-customizing-git#_enforcing_commit_message_format>>.
-If you pass `--objects` to `rev-list`, it lists all the commit SHA-1s and also the blob SHA-1s with the file paths associated with them.
-You can use this to find your blob's name:
+Object بزرگ در پایین است: ۵MB.
+برای اینکه بفهمید این فایل چیست، از دستور `rev-list` استفاده می‌کنید، که قبلاً در بخش <<ch08-customizing-git#_enforcing_commit_message_format>> مختصری با آن آشنا شدید.
+اگر گزینه `--objects` را به `rev-list` بدهید، تمام commit SHA-1ها و همچنین blob SHA-1ها را همراه با مسیر فایل‌های مربوطه لیست می‌کند.
+می‌توانید از این برای پیدا کردن نام blob خود استفاده کنید:
 
 [source,console]
 ----
@@ -272,8 +263,8 @@ $ git rev-list --objects --all | grep 82c99a3
 82c99a3e86bb1267b236a4b6eff7868d97489af1 git.tgz
 ----
 
-Now, you need to remove this file from all trees in your past.
-You can easily see what commits modified this file:
+حالا، باید این فایل را از همه treeهای گذشته حذف کنید.
+به‌راحتی می‌توانید ببینید چه commitهایی این فایل را تغییر داده‌اند:
 
 [source,console]
 ----
@@ -282,8 +273,8 @@ dadf725 Oops - remove large tarball
 7b30847 Add git tarball
 ----
 
-You must rewrite all the commits downstream from `7b30847` to fully remove this file from your Git history.
-To do so, you use `filter-branch`, which you used in <<ch07-git-tools#_rewriting_history>>:
+شما باید تمام commitهایی که downstream از `7b30847` هستند را بازنویسی کنید تا این فایل به طور کامل از Git history حذف شود.
+برای این کار، از `filter-branch` استفاده می‌کنید که قبلاً در بخش <<ch07-git-tools#_rewriting_history>> دیدید:
 
 [source,console]
 ----
@@ -294,18 +285,18 @@ Rewrite dadf7258d699da2c8d89b09ef6670edb7d5f91b4 (2/2)
 Ref 'refs/heads/master' was rewritten
 ----
 
-The `--index-filter` option is similar to the `--tree-filter` option used in <<ch07-git-tools#_rewriting_history>>, except that instead of passing a command that modifies files checked out on disk, you're modifying your staging area or index each time.
+گزینه‌ی `--index-filter` شبیه به `--tree-filter` است که در بخش <<ch07-git-tools#_rewriting_history>> استفاده شد، با این تفاوت که به‌جای اجرای دستوری که فایل‌های checkout‌شده روی disk را تغییر می‌دهد، هر بار staging area یا index را تغییر می‌دهید.
 
-Rather than remove a specific file with something like `rm file`, you have to remove it with `git rm --cached` – you must remove it from the index, not from disk.
-The reason to do it this way is speed – because Git doesn't have to check out each revision to disk before running your filter, the process can be much, much faster.
-You can accomplish the same task with `--tree-filter` if you want.
-The `--ignore-unmatch` option to `git rm` tells it not to error out if the pattern you're trying to remove isn't there.
-Finally, you ask `filter-branch` to rewrite your history only from the `7b30847` commit up, because you know that is where this problem started.
-Otherwise, it will start from the beginning and will unnecessarily take longer.
+به‌جای اینکه یک فایل خاص را با چیزی مثل `rm file` حذف کنید، باید آن را با `git rm --cached` حذف کنید – باید از index حذف شود، نه از disk.
+دلیل این روش، سرعت است – چون Git مجبور نیست هر نسخه را روی disk checkout کند، فرآیند بسیار سریع‌تر خواهد بود.
+می‌توانید همین کار را با `--tree-filter` هم انجام دهید اگر بخواهید.
+گزینه‌ی `--ignore-unmatch` برای `git rm` باعث می‌شود اگر الگوی مورد نظر شما وجود نداشت، خطا ندهد.
+در نهایت، به `filter-branch` می‌گویید که history را فقط از commit `7b30847` به بعد بازنویسی کند، چون می‌دانید مشکل از آنجا شروع شده.
+در غیر این صورت، از ابتدا شروع می‌کند و بی‌دلیل زمان بیشتری می‌گیرد.
 
-Your history no longer contains a reference to that file.
-However, your reflog and a new set of refs that Git added when you did the `filter-branch` under `.git/refs/original` still do, so you have to remove them and then repack the database.
-You need to get rid of anything that has a pointer to those old commits before you repack:
+History شما دیگر حاوی reference به آن فایل نیست.
+اما reflog شما و مجموعه جدیدی از refs که Git هنگام اجرای `filter-branch` در `.git/refs/original` ایجاد کرده همچنان آن را دارند، بنابراین باید آن‌ها را حذف کنید و سپس دیتابیس را دوباره repack کنید.
+باید هر چیزی که به آن commitهای قدیمی اشاره دارد را پاک کنید قبل از اینکه repack انجام دهید:
 
 [source,console]
 ----
@@ -319,7 +310,7 @@ Writing objects: 100% (15/15), done.
 Total 15 (delta 1), reused 12 (delta 0)
 ----
 
-Let's see how much space you saved.
+ببینیم چقدر فضا ذخیره کردید.
 
 [source,console]
 ----
@@ -334,9 +325,9 @@ garbage: 0
 size-garbage: 0
 ----
 
-The packed repository size is down to 8K, which is much better than 5MB.
-You can see from the size value that the big object is still in your loose objects, so it's not gone; but it won't be transferred on a push or subsequent clone, which is what is important.
-If you really wanted to, you could remove the object completely by running `git prune` with the `--expire` option:
+اندازه‌ی packed repository به 8K کاهش یافته که بسیار بهتر از ۵MB است.
+از مقدار size می‌توانید ببینید که object بزرگ همچنان در loose objects وجود دارد، پس کاملاً حذف نشده؛ اما هنگام push یا clone بعدی منتقل نخواهد شد، که همین مهم است.
+اگر واقعاً بخواهید، می‌توانید با اجرای `git prune` همراه با گزینه‌ی `--expire` آن object را کاملاً حذف کنید:
 
 [source,console]
 ----

--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -1,15 +1,14 @@
 [[_objects]]
-=== Git Objects
+=== Git Objects (اشیا گیت)
 
-Git is a content-addressable filesystem.
-Great.
-What does that mean?
-It means that at the core of Git is a simple key-value data store.
-What this means is that you can insert any kind of content into a Git repository, for which Git will hand you back a unique key you can use later to retrieve that content.
+Git یک **content-addressable filesystem** است.
+خیلی خوب. این یعنی چی؟
+یعنی در هسته‌ی Git یک **key-value data store** ساده قرار دارد.
+به این معنا که شما می‌توانید هر نوع محتوایی را داخل یک Git repository وارد کنید و Git یک کلید یکتا به شما برمی‌گرداند که بعداً می‌توانید با آن کلید، محتوای خود را بازیابی کنید.
 
-As a demonstration, let's look at the plumbing command `git hash-object`, which takes some data, stores it in your `.git/objects` directory (the _object database_), and gives you back the unique key that now refers to that data object.
+به‌عنوان یک نمایش عملی، بیایید به دستور plumbing به نام `git hash-object` نگاه کنیم؛ این دستور داده‌ای را دریافت می‌کند، آن را داخل دایرکتوری `.git/objects` (یعنی **object database**) ذخیره می‌کند، و کلید یکتایی به شما برمی‌گرداند که به آن object اشاره دارد.
 
-First, you initialize a new Git repository and verify that there is (predictably) nothing in the `objects` directory:
+ابتدا یک Git repository جدید initialize کنید و مطمئن شوید که (قابل پیش‌بینی است) چیزی در دایرکتوری `objects` وجود ندارد:
 
 [source,console]
 ----
@@ -23,8 +22,8 @@ $ find .git/objects
 $ find .git/objects -type f
 ----
 
-Git has initialized the `objects` directory and created `pack` and `info` subdirectories in it, but there are no regular files.
-Now, let's use `git hash-object` to create a new data object and manually store it in your new Git database:
+Git دایرکتوری `objects` را ساخته و زیرشاخه‌های `pack` و `info` را ایجاد کرده، اما هیچ فایل عادی وجود ندارد.
+حالا بیایید با `git hash-object` یک data object جدید بسازیم و آن را به‌صورت دستی در Git database ذخیره کنیم:
 
 [source,console]
 ----
@@ -32,13 +31,13 @@ $ echo 'test content' | git hash-object -w --stdin
 d670460b4b4aece5915caf5c68d12f560a9fe3e4
 ----
 
-In its simplest form, `git hash-object` would take the content you handed to it and merely return the unique key that _would_ be used to store it in your Git database.
-The `-w` option then tells the command to not simply return the key, but to write that object to the database.
-Finally, the `--stdin` option tells `git hash-object` to get the content to be processed from stdin; otherwise, the command would expect a filename argument at the end of the command containing the content to be used.
+در ساده‌ترین حالت، `git hash-object` محتوایی که به آن می‌دهید را می‌گیرد و صرفاً کلید یکتایی برمی‌گرداند که *می‌تواند* برای ذخیره‌ی آن محتوا در Git database استفاده شود.
+گزینه `-w` به دستور می‌گوید که فقط کلید را برنگرداند، بلکه object را واقعاً در database بنویسد.
+گزینه `--stdin` هم به `git hash-object` می‌گوید که محتوا را از **stdin** دریافت کند؛ در غیر این صورت، دستور انتظار دارد نام فایلی در انتهای دستور داده شود که شامل محتوای مورد استفاده است.
 
-The output from the above command is a 40-character checksum hash.
-This is the SHA-1 hash -- a checksum of the content you're storing plus a header, which you'll learn about in a bit.
-Now you can see how Git has stored your data:
+خروجی دستور بالا یک hash ۴۰ کاراکتری است.
+این همان **SHA-1 hash** است – یک checksum از محتوایی که ذخیره کرده‌اید به‌علاوه‌ی یک header (که کمی بعد یاد می‌گیرید).
+حالا می‌توانید ببینید Git چطور داده‌های شما را ذخیره کرده است:
 
 [source,console]
 ----
@@ -46,13 +45,13 @@ $ find .git/objects -type f
 .git/objects/d6/70460b4b4aece5915caf5c68d12f560a9fe3e4
 ----
 
-If you again examine your `objects` directory, you can see that it now contains a file for that new content.
-This is how Git stores the content initially -- as a single file per piece of content, named with the SHA-1 checksum of the content and its header.
-The subdirectory is named with the first 2 characters of the SHA-1, and the filename is the remaining 38 characters.
+اگر دوباره دایرکتوری `objects` را بررسی کنید، می‌بینید که حالا یک فایل برای آن محتوای جدید وجود دارد.
+Git محتوا را در ابتدا به این شکل ذخیره می‌کند – یک فایل به‌ازای هر قطعه‌ی محتوا، با نامی که از SHA-1 آن محتوا و header گرفته شده است.
+زیرشاخه با دو کاراکتر اول SHA-1 نام‌گذاری می‌شود و اسم فایل، ۳۸ کاراکتر باقی‌مانده است.
 
-Once you have content in your object database, you can examine that content with the `git cat-file` command.
-This command is sort of a Swiss army knife for inspecting Git objects.
-Passing `-p` to `cat-file` instructs the command to first figure out the type of content, then display it appropriately:
+وقتی محتوایی در object database دارید، می‌توانید با دستور `git cat-file` آن محتوا را بررسی کنید.
+این دستور مثل یک **چاقوی سوئیسی** برای مشاهده‌ی Git objectهاست.
+اگر به آن `-p` بدهید، اول نوع object را تشخیص می‌دهد و سپس آن را به‌درستی نمایش می‌دهد:
 
 [source,console]
 ----
@@ -60,10 +59,10 @@ $ git cat-file -p d670460b4b4aece5915caf5c68d12f560a9fe3e4
 test content
 ----
 
-Now, you can add content to Git and pull it back out again.
-You can also do this with content in files.
-For example, you can do some simple version control on a file.
-First, create a new file and save its contents in your database:
+حالا می‌توانید محتوایی به Git اضافه کنید و دوباره آن را بیرون بکشید.
+همچنین می‌توانید همین کار را با فایل‌ها انجام دهید.
+برای مثال، می‌توانید روی یک فایل ساده، نسخه‌سازی انجام دهید.
+ابتدا یک فایل جدید بسازید و محتوای آن را در database ذخیره کنید:
 
 [source,console]
 ----
@@ -72,7 +71,7 @@ $ git hash-object -w test.txt
 83baae61804e65cc73a7201a7252750c76066a30
 ----
 
-Then, write some new content to the file, and save it again:
+سپس محتوای جدیدی در فایل بنویسید و دوباره آن را ذخیره کنید:
 
 [source,console]
 ----
@@ -81,7 +80,7 @@ $ git hash-object -w test.txt
 1f7a7a472abf3dd9643fd615f6da379c4acb3e3a
 ----
 
-Your object database now contains both versions of this new file (as well as the first content you stored there):
+Database شما حالا هر دو نسخه‌ی این فایل جدید (به‌علاوه‌ی اولین محتوایی که ذخیره کرده‌اید) را دارد:
 
 [source,console]
 ----
@@ -91,7 +90,8 @@ $ find .git/objects -type f
 .git/objects/d6/70460b4b4aece5915caf5c68d12f560a9fe3e4
 ----
 
-At this point, you can delete your local copy of that `test.txt` file, then use Git to retrieve, from the object database, either the first version you saved:
+در این مرحله، می‌توانید نسخه‌ی محلی فایل `test.txt` را پاک کنید، سپس با Git آن را از database بازیابی کنید؛
+یا نسخه‌ی اولی را:
 
 [source,console]
 ----
@@ -100,7 +100,7 @@ $ cat test.txt
 version 1
 ----
 
-or the second version:
+یا نسخه‌ی دومی را:
 
 [source,console]
 ----
@@ -109,9 +109,9 @@ $ cat test.txt
 version 2
 ----
 
-But remembering the SHA-1 key for each version of your file isn't practical; plus, you aren't storing the filename in your system -- just the content.
-This object type is called a _blob_.
-You can have Git tell you the object type of any object in Git, given its SHA-1 key, with `git cat-file -t`:
+اما به خاطر سپردن کلید SHA-1 هر نسخه از فایل عملی نیست؛ به‌علاوه، شما نام فایل را در سیستم ذخیره نمی‌کنید – فقط محتوا ذخیره می‌شود.
+این نوع object را یک **blob** می‌نامند.
+می‌توانید با دستور `git cat-file -t` و داشتن کلید SHA-1، نوع هر object را در Git ببینید:
 
 [source,console]
 ----
@@ -120,13 +120,13 @@ blob
 ----
 
 [[_tree_objects]]
-==== Tree Objects
+==== Tree Objects (درخت اشیاء)
 
-The next type of Git object we'll examine is the _tree_, which solves the problem of storing the filename and also allows you to store a group of files together.
-Git stores content in a manner similar to a UNIX filesystem, but a bit simplified.
-All the content is stored as tree and blob objects, with trees corresponding to UNIX directory entries and blobs corresponding more or less to inodes or file contents.
-A single tree object contains one or more entries, each of which is the SHA-1 hash of a blob or subtree with its associated mode, type, and filename.
-For example, let's say you have a project where the most-recent tree looks something like:
+نوع بعدی Git object که بررسی می‌کنیم **tree** است؛ این مشکل را حل می‌کند که نام فایل هم ذخیره شود و علاوه بر آن امکان ذخیره‌ی گروهی از فایل‌ها را هم فراهم می‌کند.
+Git داده‌ها را به شکلی شبیه به فایل‌سیستم UNIX ذخیره می‌کند، اما کمی ساده‌تر.
+همه‌ی محتوا به‌صورت **tree** و **blob** ذخیره می‌شود؛ treeها مشابه ورودی‌های دایرکتوری در UNIX هستند و blobها تقریباً متناظر با inodeها یا محتوای فایل‌ها.
+یک tree object شامل یک یا چند ورودی است؛ هرکدام یک SHA-1 hash از یک blob یا subtree همراه با mode، نوع (type) و نام فایل هستند.
+مثلاً فرض کنید پروژه‌ای دارید که آخرین tree آن چیزی شبیه این است:
 
 [source,console]
 ----
@@ -136,8 +136,8 @@ $ git cat-file -p master^{tree}
 040000 tree 99f1a6d12cb4b6f19c8655fca46c3ecf317074e0      lib
 ----
 
-The `master^{tree}` syntax specifies the tree object that is pointed to by the last commit on your `master` branch.
-Notice that the `lib` subdirectory isn't a blob but a pointer to another tree:
+سینتکس `master^{tree}` مشخص می‌کند که کدام tree object توسط آخرین commit روی شاخه‌ی `master` اشاره می‌شود.
+دقت کنید که زیرشاخه‌ی `lib` یک blob نیست، بلکه یک اشاره‌گر به یک tree دیگر است:
 
 [source,console]
 ----
@@ -147,26 +147,28 @@ $ git cat-file -p 99f1a6d12cb4b6f19c8655fca46c3ecf317074e0
 
 [NOTE]
 ====
-Depending on what shell you use, you may encounter errors when using the `master^{tree}` syntax.
+بسته به اینکه از چه shellی استفاده می‌کنید، ممکن است هنگام استفاده از سینتکس `master^{tree}` به خطا بخورید.
 
-In CMD on Windows, the `^` character is used for escaping, so you have to double it to avoid this: `git cat-file -p master^^{tree}`.
-When using PowerShell, parameters using `{}` characters have to be quoted to avoid the parameter being parsed incorrectly: `git cat-file -p 'master^{tree}'`.
-
-If you're using ZSH, the `^` character is used for globbing, so you have to enclose the whole expression in quotes: `git cat-file -p "master^{tree}"`.
+- در CMD روی Windows، کاراکتر `^` برای escaping استفاده می‌شود، پس باید آن را دوبل کنید:
+  `git cat-file -p master^^{tree}`
+- در PowerShell، پارامترهایی که از `{}` استفاده می‌کنند باید کوتیشن شوند:
+  `git cat-file -p 'master^{tree}'`
+- در ZSH، کاراکتر `^` برای globbing استفاده می‌شود، پس باید کل عبارت را در کوتیشن بگذارید:
+  `git cat-file -p "master^{tree}"`
 ====
 
-Conceptually, the data that Git is storing looks something like this:
+از نظر مفهومی، داده‌ای که Git ذخیره می‌کند چیزی شبیه این است:
 
 .Simple version of the Git data model
 image::images/data-model-1.png[Simple version of the Git data model]
 
-You can fairly easily create your own tree.
-Git normally creates a tree by taking the state of your staging area or index and writing a series of tree objects from it.
-So, to create a tree object, you first have to set up an index by staging some files.
-To create an index with a single entry -- the first version of your `test.txt` file -- you can use the plumbing command `git update-index`.
-You use this command to artificially add the earlier version of the `test.txt` file to a new staging area.
-You must pass it the `--add` option because the file doesn't yet exist in your staging area (you don't even have a staging area set up yet) and `--cacheinfo` because the file you're adding isn't in your directory but is in your database.
-Then, you specify the mode, SHA-1, and filename:
+شما می‌توانید به‌راحتی tree خودتان را بسازید.
+معمولاً Git با گرفتن وضعیت staging area یا index شما و نوشتن مجموعه‌ای از tree objectها از آن، یک tree می‌سازد.
+پس برای ایجاد یک tree object، ابتدا باید یک index با staging بعضی فایل‌ها بسازید.
+برای ساخت یک index با یک ورودی – اولین نسخه‌ی فایل `test.txt` – می‌توانید از دستور plumbing به نام `git update-index` استفاده کنید.
+این دستور را برای اضافه کردن نسخه‌ی قبلی `test.txt` به یک staging area جدید استفاده می‌کنید.
+باید گزینه‌ی `--add` را بدهید چون فایل هنوز در staging area وجود ندارد (حتی staging area هم هنوز ساخته نشده) و `--cacheinfo` چون فایلی که اضافه می‌کنید روی دایرکتوری نیست بلکه در database است.
+سپس mode، SHA-1 و نام فایل را مشخص می‌کنید:
 
 [source,console]
 ----
@@ -174,12 +176,12 @@ $ git update-index --add --cacheinfo 100644 \
   83baae61804e65cc73a7201a7252750c76066a30 test.txt
 ----
 
-In this case, you're specifying a mode of `100644`, which means it's a normal file.
-Other options are `100755`, which means it's an executable file; and `120000`, which specifies a symbolic link.
-The mode is taken from normal UNIX modes but is much less flexible -- these three modes are the only ones that are valid for files (blobs) in Git (although other modes are used for directories and submodules).
+در اینجا، شما یک mode با مقدار `100644` مشخص می‌کنید که به معنی یک فایل عادی است.
+گزینه‌های دیگر عبارتند از: `100755` برای فایل اجرایی (executable) و `120000` برای لینک نمادین (symbolic link).
+Mode از حالت‌های استاندارد UNIX گرفته شده اما بسیار ساده‌تر است – این سه حالت تنها مقادیر معتبر برای فایل‌ها (blobها) در Git هستند (البته modeهای دیگری برای دایرکتوری‌ها و submoduleها استفاده می‌شوند).
 
-Now, you can use `git write-tree` to write the staging area out to a tree object.
-No `-w` option is needed -- calling this command automatically creates a tree object from the state of the index if that tree doesn't yet exist:
+حالا می‌توانید با دستور `git write-tree` محتوای staging area را به یک tree object بنویسید.
+نیازی به گزینه `-w` نیست – اجرای این دستور به‌طور خودکار یک tree object از وضعیت index ایجاد می‌کند اگر هنوز وجود نداشته باشد:
 
 [source,console]
 ----
@@ -189,7 +191,7 @@ $ git cat-file -p d8329fc1cc938780ffdd9f94e0d364e0ea74f579
 100644 blob 83baae61804e65cc73a7201a7252750c76066a30      test.txt
 ----
 
-You can also verify that this is a tree object using the same `git cat-file` command you saw earlier:
+می‌توانید با همان دستور `git cat-file` که قبلاً دیدید، بررسی کنید که این یک tree object است:
 
 [source,console]
 ----
@@ -197,7 +199,7 @@ $ git cat-file -t d8329fc1cc938780ffdd9f94e0d364e0ea74f579
 tree
 ----
 
-You'll now create a new tree with the second version of `test.txt` and a new file as well:
+حالا یک tree جدید با نسخه دوم فایل `test.txt` و همچنین یک فایل جدید ایجاد می‌کنید:
 
 [source,console]
 ----
@@ -207,8 +209,8 @@ $ git update-index --cacheinfo 100644 \
 $ git update-index --add new.txt
 ----
 
-Your staging area now has the new version of `test.txt` as well as the new file `new.txt`.
-Write out that tree (recording the state of the staging area or index to a tree object) and see what it looks like:
+staging area شما حالا شامل نسخه جدید `test.txt` و همچنین فایل `new.txt` است.
+tree جدید را بنویسید (ثبت وضعیت staging area یا index به‌عنوان یک tree object) و ببینید چه شکلی است:
 
 [source,console]
 ----
@@ -219,10 +221,10 @@ $ git cat-file -p 0155eb4229851634a0f03eb265b69f5a2d56f341
 100644 blob 1f7a7a472abf3dd9643fd615f6da379c4acb3e3a      test.txt
 ----
 
-Notice that this tree has both file entries and also that the `test.txt` SHA-1 is the "`version 2`" SHA-1 from earlier (`1f7a7a`).
-Just for fun, you'll add the first tree as a subdirectory into this one.
-You can read trees into your staging area by calling `git read-tree`.
-In this case, you can read an existing tree into your staging area as a subtree by using the `--prefix` option with this command:
+دقت کنید که این tree هم فایل‌های مختلف دارد و هم اینکه SHA-1 مربوط به `test.txt` همان SHA-1 نسخه دوم از قبل (`1f7a7a`) است.
+برای سرگرمی، شما tree اول را به‌عنوان یک زیرشاخه به این tree اضافه می‌کنید.
+می‌توانید treeها را با دستور `git read-tree` به staging area بخوانید.
+در اینجا، با استفاده از گزینه‌ی `--prefix` یک tree موجود را به‌عنوان subtree وارد staging area می‌کنید:
 
 [source,console]
 ----
@@ -235,21 +237,21 @@ $ git cat-file -p 3c4e9cd789d88d8d89c1073707c3585e41b0e614
 100644 blob 1f7a7a472abf3dd9643fd615f6da379c4acb3e3a      test.txt
 ----
 
-If you created a working directory from the new tree you just wrote, you would get the two files in the top level of the working directory and a subdirectory named `bak` that contained the first version of the `test.txt` file.
-You can think of the data that Git contains for these structures as being like this:
+اگر از tree جدیدی که نوشتید یک working directory بسازید، دو فایل در سطح اصلی working directory خواهید داشت و یک زیرشاخه به نام `bak` که شامل نسخه اول فایل `test.txt` است.
+می‌توانید داده‌ای که Git برای این ساختارها ذخیره می‌کند را این‌گونه تصور کنید:
 
 .The content structure of your current Git data
 image::images/data-model-2.png[The content structure of your current Git data]
 
 [[_git_commit_objects]]
-==== Commit Objects
+==== Commit Objects (کامیت اشیاء)
 
-If you've done all of the above, you now have three trees that represent the different snapshots of your project that you want to track, but the earlier problem remains: you must remember all three SHA-1 values in order to recall the snapshots.
-You also don't have any information about who saved the snapshots, when they were saved, or why they were saved.
-This is the basic information that the commit object stores for you.
+اگر همه‌ی مراحل بالا را انجام داده باشید، اکنون سه tree دارید که snapshotهای مختلف پروژه شما را نمایش می‌دهند؛ اما مشکل قبلی باقی‌ست: باید هر سه SHA-1 را به خاطر بسپارید تا بتوانید snapshotها را بازیابی کنید.
+همچنین هیچ اطلاعاتی درباره اینکه چه کسی snapshotها را ذخیره کرده، چه زمانی و چرا ذخیره شده‌اند، ندارید.
+این همان اطلاعات پایه‌ای است که یک **commit object** برای شما ذخیره می‌کند.
 
-To create a commit object, you call `commit-tree` and specify a single tree SHA-1 and which commit objects, if any, directly preceded it.
-Start with the first tree you wrote:
+برای ایجاد یک commit object، دستور `commit-tree` را فراخوانی کرده و یک tree SHA-1 و commitهای قبلی (در صورت وجود) را مشخص می‌کنید.
+با اولین tree که نوشتید شروع کنید:
 
 [source,console]
 ----
@@ -259,12 +261,12 @@ fdf4fc3344e67ab068f836878b6c4951e3b15f3d
 
 [NOTE]
 ====
-You will get a different hash value because of different creation time and author data.
-Moreover, while in principle any commit object can be reproduced precisely given that data, historical details of this book's construction mean that the printed commit hashes might not correspond to the given commits.
-Replace commit and tag hashes with your own checksums further in this chapter.
+شما یک hash متفاوت دریافت خواهید کرد، چون زمان ایجاد و داده‌های نویسنده متفاوت است.
+در اصل، هر commit object با داشتن آن داده‌ها می‌تواند به‌طور دقیق بازتولید شود، اما جزئیات تاریخیِ تهیه این کتاب باعث می‌شود commit hashهای چاپ‌شده الزاماً با commitهای داده‌شده یکی نباشند.
+در ادامه، commit و tag hashها را با checksumهای خودتان جایگزین کنید.
 ====
 
-Now you can look at your new commit object with `git cat-file`:
+حالا می‌توانید commit object جدید خود را با دستور `git cat-file` بررسی کنید:
 
 [source,console]
 ----
@@ -276,9 +278,9 @@ committer Scott Chacon <schacon@gmail.com> 1243040974 -0700
 First commit
 ----
 
-The format for a commit object is simple: it specifies the top-level tree for the snapshot of the project at that point; the parent commits if any (the commit object described above does not have any parents); the author/committer information (which uses your `user.name` and `user.email` configuration settings and a timestamp); a blank line, and then the commit message.
+فرمت یک commit object ساده است: مشخص می‌کند که tree سطح بالا برای snapshot پروژه در آن نقطه چیست؛ commitهای والد در صورت وجود (commit بالا هیچ والدی ندارد)؛ اطلاعات author/committer (که از تنظیمات `user.name` و `user.email` شما و یک timestamp استفاده می‌کند)؛ یک خط خالی و سپس پیام commit.
 
-Next, you'll write the other two commit objects, each referencing the commit that came directly before it:
+سپس، دو commit object دیگر را می‌نویسید که هرکدام به commit قبلی خود اشاره دارند:
 
 [source,console]
 ----
@@ -288,8 +290,8 @@ $ echo 'Third commit'  | git commit-tree 3c4e9c -p cac0cab
 1a410efbd13591db07496601ebc7a059dd55cfe9
 ----
 
-Each of the three commit objects points to one of the three snapshot trees you created.
-Oddly enough, you have a real Git history now that you can view with the `git log` command, if you run it on the last commit SHA-1:
+هر سه commit object به یکی از سه snapshot treeای که ساخته‌اید اشاره می‌کنند.
+جالب است که حالا یک Git history واقعی دارید که می‌توانید با اجرای `git log` روی آخرین commit SHA-1 آن را ببینید:
 
 [source,console]
 ----
@@ -323,11 +325,11 @@ Date:   Fri May 22 18:09:34 2009 -0700
  1 file changed, 1 insertion(+)
 ----
 
-Amazing.
-You've just done the low-level operations to build up a Git history without using any of the front end commands.
-This is essentially what Git does when you run the `git add` and `git commit` commands -- it stores blobs for the files that have changed, updates the index, writes out trees, and writes commit objects that reference the top-level trees and the commits that came immediately before them.
-These three main Git objects -- the blob, the tree, and the commit -- are initially stored as separate files in your `.git/objects` directory.
-Here are all the objects in the example directory now, commented with what they store:
+شگفت‌انگیز است.
+شما به‌تازگی عملیات سطح پایین برای ساختن یک Git history را بدون استفاده از دستورات front-end انجام دادید.
+این دقیقاً همان کاری است که Git هنگام اجرای `git add` و `git commit` انجام می‌دهد – blobهایی برای فایل‌های تغییر یافته ذخیره می‌کند، index را به‌روزرسانی می‌کند، treeها را می‌نویسد و commit objectهایی که به treeهای سطح بالا و commitهای قبلی اشاره دارند ایجاد می‌کند.
+این سه Git object اصلی – **blob**، **tree** و **commit** – در ابتدا به‌عنوان فایل‌های جداگانه در دایرکتوری `.git/objects` ذخیره می‌شوند.
+در اینجا همه objectهای موجود در دایرکتوری مثال را می‌بینید که هرکدام با توضیح آنچه ذخیره می‌کنند، مشخص شده‌اند:
 
 [source,console]
 ----
@@ -344,18 +346,18 @@ $ find .git/objects -type f
 .git/objects/fd/f4fc3344e67ab068f836878b6c4951e3b15f3d # commit 1
 ----
 
-If you follow all the internal pointers, you get an object graph something like this:
+اگر تمام اشاره‌گرهای داخلی را دنبال کنید، یک object graph شبیه این خواهید داشت:
 
 .All the reachable objects in your Git directory
 image::images/data-model-3.png[All the reachable objects in your Git directory]
 
-==== Object Storage
+==== Object Storage (ذخیره سازی اشیاء)
 
-We mentioned earlier that there is a header stored with every object you commit to your Git object database.
-Let's take a minute to see how Git stores its objects.
-You'll see how to store a blob object -- in this case, the string "`what is up, doc?`" -- interactively in the Ruby scripting language.
+پیش‌تر اشاره کردیم که همراه هر object که در Git database ذخیره می‌کنید، یک header هم وجود دارد.
+بیایید ببینیم Git چطور objectها را ذخیره می‌کند.
+شما می‌بینید که چگونه می‌توان یک blob object – در این مثال رشته‌ی "`what is up, doc?`" – را به‌صورت تعاملی در زبان Ruby ذخیره کرد.
 
-You can start up interactive Ruby mode with the `irb` command:
+می‌توانید حالت تعاملی Ruby را با دستور `irb` اجرا کنید:
 
 [source,console]
 ----
@@ -364,8 +366,8 @@ $ irb
 => "what is up, doc?"
 ----
 
-Git first constructs a header which starts by identifying the type of object -- in this case, a blob.
-To that first part of the header, Git adds a space followed by the size in bytes of the content, and adding a final null byte:
+Git ابتدا یک header می‌سازد که نوع object (در اینجا blob) را مشخص می‌کند.
+به این بخش اول header، یک فاصله و سپس اندازه محتوای برحسب بایت اضافه می‌شود و در انتها یک null byte قرار می‌گیرد:
 
 [source,console]
 ----
@@ -373,8 +375,8 @@ To that first part of the header, Git adds a space followed by the size in bytes
 => "blob 16\u0000"
 ----
 
-Git concatenates the header and the original content and then calculates the SHA-1 checksum of that new content.
-You can calculate the SHA-1 value of a string in Ruby by including the SHA1 digest library with the `require` command and then calling `Digest::SHA1.hexdigest()` with the string:
+سپس Git این header و محتوای اصلی را به هم متصل کرده و checksum آن را با الگوریتم SHA-1 محاسبه می‌کند.
+در Ruby می‌توانید مقدار SHA-1 یک رشته را با include کردن کتابخانه‌ی SHA1 digest با دستور `require` و سپس فراخوانی `Digest::SHA1.hexdigest()` محاسبه کنید:
 
 [source,console]
 ----
@@ -386,8 +388,8 @@ You can calculate the SHA-1 value of a string in Ruby by including the SHA1 dige
 => "bd9dbf5aae1a3862dd1526723246b20206e5fc37"
 ----
 
-Let's compare that to the output of `git hash-object`.
-Here we use `echo -n` to prevent adding a newline to the input.
+بیایید این را با خروجی دستور `git hash-object` مقایسه کنیم.
+اینجا از `echo -n` استفاده می‌کنیم تا یک newline به ورودی اضافه نشود:
 
 [source,console]
 ----
@@ -395,8 +397,8 @@ $ echo -n "what is up, doc?" | git hash-object --stdin
 bd9dbf5aae1a3862dd1526723246b20206e5fc37
 ----
 
-Git compresses the new content with zlib, which you can do in Ruby with the zlib library.
-First, you need to require the library and then run `Zlib::Deflate.deflate()` on the content:
+Git محتوای جدید را با zlib فشرده می‌کند؛ در Ruby هم می‌توانید با کتابخانه‌ی zlib این کار را انجام دهید.
+ابتدا باید کتابخانه را require کنید و سپس `Zlib::Deflate.deflate()` را روی محتوا اجرا کنید:
 
 [source,console]
 ----
@@ -406,10 +408,10 @@ First, you need to require the library and then run `Zlib::Deflate.deflate()` on
 => "x\x9CK\xCA\xC9OR04c(\xCFH,Q\xC8,V(-\xD0QH\xC9O\xB6\a\x00_\x1C\a\x9D"
 ----
 
-Finally, you'll write your zlib-deflated content to an object on disk.
-You'll determine the path of the object you want to write out (the first two characters of the SHA-1 value being the subdirectory name, and the last 38 characters being the filename within that directory).
-In Ruby, you can use the `FileUtils.mkdir_p()` function to create the subdirectory if it doesn't exist.
-Then, open the file with `File.open()` and write out the previously zlib-compressed content to the file with a `write()` call on the resulting file handle:
+در نهایت، محتوای فشرده‌شده با zlib را روی دیسک به‌عنوان یک object می‌نویسید.
+مسیر object را بر اساس SHA-1 تعیین می‌کنید (دو کاراکتر اول به‌عنوان نام زیرشاخه و ۳۸ کاراکتر باقی‌مانده به‌عنوان نام فایل درون آن دایرکتوری).
+در Ruby می‌توانید از تابع `FileUtils.mkdir_p()` برای ایجاد زیرشاخه در صورت عدم وجود آن استفاده کنید.
+سپس فایل را با `File.open()` باز کرده و محتوای فشرده‌شده را با یک فراخوانی `write()` روی file handle ایجادشده بنویسید:
 
 [source,console]
 ----
@@ -423,7 +425,7 @@ Then, open the file with `File.open()` and write out the previously zlib-compres
 => 32
 ----
 
-Let's check the content of the object using `git cat-file`:
+حالا محتوای object را با دستور `git cat-file` بررسی کنید:
 
 [source,console]
 ---
@@ -431,7 +433,7 @@ $ git cat-file -p bd9dbf5aae1a3862dd1526723246b20206e5fc37
 what is up, doc?
 ---
 
-That's it – you've created a valid Git blob object.
+همین! شما یک Git blob object معتبر ساخته‌اید.
 
-All Git objects are stored the same way, just with different types – instead of the string blob, the header will begin with commit or tree.
-Also, although the blob content can be nearly anything, the commit and tree content are very specifically formatted.
+تمام Git objectها به همین شیوه ذخیره می‌شوند، فقط نوع آن‌ها متفاوت است – به‌جای رشته‌ی blob، header با commit یا tree شروع می‌شود.
+همچنین، در حالی که محتوای blob می‌تواند تقریباً هر چیزی باشد، محتوای commit و tree ساختار بسیار مشخصی دارند.

--- a/book/10-git-internals/sections/packfiles.asc
+++ b/book/10-git-internals/sections/packfiles.asc
@@ -1,6 +1,6 @@
-=== Packfiles
+=== Packfiles (فایل‌های بسته)
 
-If you followed all of the instructions in the example from the previous section, you should now have a test Git repository with 11 objects -- four blobs, three trees, three commits, and one tag:
+اگر دستورالعمل‌های مثال بخش قبلی را دنبال کرده باشید، اکنون باید یک مخزن Git آزمایشی با ۱۱ شیء داشته باشید — چهار blob، سه tree، سه commit و یک tag:
 
 [source,console]
 ----
@@ -18,9 +18,9 @@ $ find .git/objects -type f
 .git/objects/fd/f4fc3344e67ab068f836878b6c4951e3b15f3d # commit 1
 ----
 
-Git compresses the contents of these files with zlib, and you're not storing much, so all these files collectively take up only 925 bytes.
-Now you'll add some more sizable content to the repository to demonstrate an interesting feature of Git.
-To demonstrate, we'll add the `repo.rb` file from the Grit library -- this is about a 22K source code file:
+Git محتوای این فایل‌ها را با zlib فشرده می‌کند و چون حجم زیادی ذخیره نکرده‌اید، مجموع این فایل‌ها تنها ۹۲۵ بایت را اشغال می‌کنند.
+حال می‌خواهیم محتوای بزرگ‌تری به مخزن اضافه کنیم تا یک ویژگی جالب Git را نشان دهیم.
+برای نشان دادن این موضوع، فایل repo.rb از کتابخانه Grit را اضافه می‌کنیم — این یک فایل کد منبع حدوداً ۲۲ کیلوبایتی است:
 
 [source,console]
 ----
@@ -35,7 +35,7 @@ $ git commit -m 'Create repo.rb'
  rewrite test.txt (100%)
 ----
 
-If you look at the resulting tree, you can see the SHA-1 value that was calculated for your new `repo.rb` blob object:
+اگر به درخت حاصل نگاه کنید، می‌توانید مقدار SHA-1 محاسبه‌شده برای شیء blob جدید repo.rb خود را ببینید:
 
 [source,console]
 ----
@@ -45,7 +45,7 @@ $ git cat-file -p master^{tree}
 100644 blob e3f094f522629ae358806b17daf78246c27c007b      test.txt
 ----
 
-You can then use `git cat-file` to see how large that object is:
+سپس می‌توانید با استفاده از `git cat-file` ببینید آن شیء چقدر بزرگ است:
 
 [source,console]
 ----
@@ -53,7 +53,7 @@ $ git cat-file -s 033b4468fa6b2a9547a70d88d1bbe8bf3f9ed0d5
 22044
 ----
 
-At this point, modify that file a little, and see what happens:
+در این مرحله، آن فایل را کمی تغییر دهید و ببینید چه اتفاقی می‌افتد:
 
 [source,console]
 ----
@@ -63,7 +63,7 @@ $ git commit -am 'Modify repo.rb a bit'
  1 file changed, 1 insertion(+)
 ----
 
-Check the tree created by that last commit, and you see something interesting:
+درختی که توسط آخرین commit ساخته شده را بررسی کنید، و نکتهٔ جالبی می‌بینید:
 
 [source,console]
 ----
@@ -73,7 +73,7 @@ $ git cat-file -p master^{tree}
 100644 blob e3f094f522629ae358806b17daf78246c27c007b      test.txt
 ----
 
-The blob is now a different blob, which means that although you added only a single line to the end of a 400-line file, Git stored that new content as a completely new object:
+آن blob اکنون یک blob متفاوت است، که یعنی با اینکه شما تنها یک خط به انتهای یک فایل ۴۰۰ خطی اضافه کرده‌اید، Git محتوای جدید را به‌صورت کامل به عنوان یک شیء جدید ذخیره کرده است:
 
 [source,console]
 ----
@@ -81,14 +81,14 @@ $ git cat-file -s b042a60ef7dff760008df33cee372b945b6e884e
 22054
 ----
 
-You have two nearly identical 22K objects on your disk (each compressed to approximately 7K).
-Wouldn't it be nice if Git could store one of them in full but then the second object only as the delta between it and the first?
+در دیسک خود دو شیء تقریباً یکسان ۲۲ کیلوبایتی دارید (هر کدام پس از فشرده‌سازی حدود ۷ کیلوبایت).
+خوب نبود اگر Git می‌توانست یکی از آن‌ها را کامل ذخیره کند و شیء دوم را فقط به صورت دلتا نسبت به اولی نگه دارد؟
 
-It turns out that it can.
-The initial format in which Git saves objects on disk is called a "`loose`" object format.
-However, occasionally Git packs up several of these objects into a single binary file called a "`packfile`" in order to save space and be more efficient.
-Git does this if you have too many loose objects around, if you run the `git gc` command manually, or if you push to a remote server.
-To see what happens, you can manually ask Git to pack up the objects by calling the `git gc` command:
+مشخص می‌شود که چنین کاری ممکن است.
+فرمت اولیه‌ای که Git اشیا را روی دیسک ذخیره می‌کند، فرمت اشیاء "`loose`" نامیده می‌شود.
+با این حال، گاهی اوقات Git چند تا از این اشیاء را در یک فایل دودویی واحد به نام "`packfile`" جمع می‌کند تا فضای ذخیره را کاهش داده و کارایی را افزایش دهد.
+Git این کار را زمانی انجام می‌دهد که اشیاء loose زیادی داشته باشید، یا دستور git gc را دستی اجرا کنید، یا وقتی که به یک سرور راه دور push می‌کنید.
+برای دیدن آنچه اتفاق می‌افتد، می‌توانید از Git بخواهید اشیاء را بسته‌بندی کند با اجرای دستور `git gc`:
 
 [source,console]
 ----
@@ -100,7 +100,7 @@ Writing objects: 100% (18/18), done.
 Total 18 (delta 3), reused 0 (delta 0)
 ----
 
-If you look in your `objects` directory, you'll find that most of your objects are gone, and a new pair of files has appeared:
+اگر به دایرکتوری `objects` خود نگاه کنید، خواهید دید که بیشتر اشیاءتان ناپدید شده‌اند و یک جفت فایل جدید ظاهر شده است:
 
 [source,console]
 ----
@@ -112,19 +112,11 @@ $ find .git/objects -type f
 .git/objects/pack/pack-978e03944f5c581011e6998cd0e9e30000905586.pack
 ----
 
-The objects that remain are the blobs that aren't pointed to by any commit -- in this case, the "`what is up, doc?`" example and the "`test content`" example blobs you created earlier.
-Because you never added them to any commits, they're considered dangling and aren't packed up in your new packfile.
+ اشیایی که باقی می‌مانند، بلاپ‌هایی هستند که هیچ کمیتی به آن‌ها اشاره نمی‌کند — در این مورد، نمونهٔ «`what is up, doc?`» و نمونهٔ «`test content`» که قبلاً ایجاد کرده بودید. چون آن‌ها را به هیچ کدام از کمیت‌ها اضافه نکرده‌اید، دورافتاده در نظر گرفته می‌شوند و در فایل پکی جدیدتان بسته‌بندی نشده‌اند.
 
-The other files are your new packfile and an index.
-The packfile is a single file containing the contents of all the objects that were removed from your filesystem.
-The index is a file that contains offsets into that packfile so you can quickly seek to a specific object.
-What is cool is that although the objects on disk before you ran the `gc` command were collectively about 15K in size, the new packfile is only 7K.
-You've cut your disk usage by half by packing your objects.
+فایل‌های دیگر، فایل پکی جدید و یک ایندکس هستند. پکی یک فایل واحد است که محتوای همهٔ اشیایی را که از سیستم فایل شما حذف شده‌اند در خود دارد. ایندکس فایلی است که افست‌ها (موقعیت‌ها) را داخل آن پکی نگه می‌دارد تا بتوانید سریعاً به یک شیٔ مشخص بپرید. نکتهٔ جالب این است که گرچه مجموع اندازهٔ اشیاء روی دیسک قبل از اجرای دستور `gc` حدود ۱۵ کیلوبایت بود، پکی جدید فقط ۷ کیلوبایت است. با بسته‌بندی اشیاء، مصرف دیسک‌تان را به نصف کاهش داده‌اید.
 
-How does Git do this?
-When Git packs objects, it looks for files that are named and sized similarly, and stores just the deltas from one version of the file to the next.
-You can look into the packfile and see what Git did to save space.
-The `git verify-pack` plumbing command allows you to see what was packed up:
+گیت این کار را چگونه انجام می‌دهد؟ وقتی گیت اشیاء را بسته‌بندی می‌کند، به دنبال فایل‌هایی می‌گردد که نام و اندازهٔ مشابهی دارند و تنها دلتاها (تفاوت‌ها) را از یک نسخهٔ فایل تا نسخهٔ بعدی ذخیره می‌کند. می‌توانید داخل پکی نگاه کنید و ببینید گیت برای صرفه‌جویی در فضا چه کاری انجام داده است. دستور plumbing یعنی `git verify-pack` به شما اجازه می‌دهد ببینید چه چیزهایی بسته‌بندی شده‌اند:
 
 [source,console]
 ----
@@ -155,9 +147,6 @@ chain length = 1: 3 objects
 .git/objects/pack/pack-978e03944f5c581011e6998cd0e9e30000905586.pack: ok
 ----
 
-Here, the `033b4` blob, which if you remember was the first version of your `repo.rb` file, is referencing the `b042a` blob, which was the second version of the file.
-The third column in the output is the size of the object in the pack, so you can see that `b042a` takes up 22K of the file, but that `033b4` only takes up 9 bytes.
-What is also interesting is that the second version of the file is the one that is stored intact, whereas the original version is stored as a delta -- this is because you're most likely to need faster access to the most recent version of the file.
+اینجا، بلاپ 033b4 که اگر یادتان باشد نسخهٔ اول فایل `repo.rb` شما بود، به بلاپ `b042a` اشاره می‌کند که نسخهٔ دوم همان فایل است. ستون سوم در خروجی، اندازهٔ شی در پکی را نشان می‌دهد، بنابراین می‌بینید `b042a` از فایل ۲۲ کیلوبایت را اشغال کرده، اما `033b4` تنها ۹ بایت حجم دارد. نکتهٔ جالب دیگر این است که نسخهٔ دوم فایل به‌صورت کامل ذخیره شده، در حالی که نسخهٔ اصلی به‌صورت دلتا نگهداری شده — چون به احتمال زیاد بیش‌تر به دسترسی سریع‌تر به جدیدترین نسخهٔ فایل نیاز خواهید داشت.
 
-The really nice thing about this is that it can be repacked at any time.
-Git will occasionally repack your database automatically, always trying to save more space, but you can also manually repack at any time by running `git gc` by hand.
+ویژگی واقعاً خوب این است که این پکی را در هر زمان می‌توان دوباره بسته‌بندی کرد. گیت گهگاه به صورت خودکار پایگاه‌دادهٔ شما را دوباره بسته‌بندی می‌کند و همیشه سعی می‌کند فضای بیش‌تری صرفه‌جویی کند، اما شما همچنین می‌توانید هر زمان که خواستید با اجرای دستی `git gc` دوباره بسته‌بندی کنید.

--- a/book/10-git-internals/sections/plumbing-porcelain.asc
+++ b/book/10-git-internals/sections/plumbing-porcelain.asc
@@ -1,18 +1,17 @@
 [[_plumbing_porcelain]]
-=== Plumbing and Porcelain
+=== Plumbing and Porcelain (ابزارها و دستورات سطح پایین)
 
-This book covers primarily how to use Git with 30 or so subcommands such as `checkout`, `branch`, `remote`, and so on.
-But because Git was initially a toolkit for a version control system rather than a full user-friendly VCS, it has a number of subcommands that do low-level work and were designed to be chained together UNIX-style or called from scripts.
-These commands are generally referred to as Git's "`plumbing`" commands, while the more user-friendly commands are called "`porcelain`" commands.
+این کتاب عمدتاً به این موضوع می‌پردازد که چگونه می‌توان با حدود ۳۰ زیرفرمان اصلی گیت مانند `checkout`، `branch`، `remote` و … کار کرد.
+اما باید توجه داشت که گیت در ابتدا به‌عنوان یک جعبه‌ابزار (toolkit) برای مدیریت نسخه طراحی شد، نه یک سیستم کنترل نسخه (VCS) کامل و کاربرپسند. به همین دلیل، بخشی از زیرفرمان‌های آن عملیات سطح‌پایین انجام می‌دهند و برای استفاده در زنجیره‌های یونیکسی (Unix pipelines) یا فراخوانی از اسکریپت‌ها ساخته شده‌اند.
 
-As you will have noticed by now, this book's first nine chapters deal almost exclusively with porcelain commands.
-But in this chapter, you'll be dealing mostly with the lower-level plumbing commands, because they give you access to the inner workings of Git, and help demonstrate how and why Git does what it does.
-Many of these commands aren't meant to be used manually on the command line, but rather to be used as building blocks for new tools and custom scripts.
+همانطور که احتمالاً تا حالا متوجه شده‌اید، نه فصل اول این کتاب تقریباً منحصراً با فرمان‌های لعاب سروکار دارند.
+اما در این فصل بیشتر با فرمان‌های سطح‌پایینِ لوله‌کشی سروکار خواهید داشت، زیرا آن‌ها دسترسی به سازوکار درونی گیت را فراهم می‌کنند و به نشان دادن این که گیت چگونه و چرا کارهایش را انجام می‌دهد کمک می‌کنند.
+بسیاری از این فرمان‌ها قرار نیست به‌صورت دستی در خط فرمان استفاده شوند، بلکه به عنوان بلوک‌های سازنده برای ابزارهای جدید و اسکریپت‌های سفارشی به کار می‌روند.
 
-When you run `git init` in a new or existing directory, Git creates the `.git` directory, which is where almost everything that Git stores and manipulates is located.
-If you want to back up or clone your repository, copying this single directory elsewhere gives you nearly everything you need.
-This entire chapter basically deals with what you can see in this directory.
-Here's what a newly-initialized `.git` directory typically looks like:
+وقتی در یک دایرکتوری جدید یا موجود `git init` اجرا می‌کنید، گیت دایرکتوری `.git` را ایجاد می‌کند که تقریباً همه چیزهایی را که گیت ذخیره و دست‌کاری می‌کند در آن قرار دارد.
+اگر بخواهید مخزن خود را پشتیبان‌گیری یا کلون کنید، کپی کردن این تک دایرکتوری به مکان دیگری تقریباً همه چیز مورد نیازتان را در اختیارتان می‌گذارد.
+کل این فصل اساساً به آنچه در این دایرکتوری می‌توانید ببینید می‌پردازد.
+در اینجا نمایی از آنچه معمولاً یک دایرکتوری تازه‌سازی‌شده `.git` به نظر می‌رسد آمده است:
 
 [source,console]
 ----
@@ -26,12 +25,12 @@ objects/
 refs/
 ----
 
-Depending on your version of Git, you may see some additional content there, but this is a fresh `git init` repository -- it's what you see by default.
-The `description` file is used only by the GitWeb program, so don't worry about it.
-The `config` file contains your project-specific configuration options, and the `info` directory keeps a global exclude file (((excludes))) for ignored patterns that you don't want to track in a `.gitignore` file.
-The `hooks` directory contains your client- or server-side hook scripts, which are discussed in detail in <<ch08-customizing-git#_git_hooks>>.
+بسته به نسخه‌ی گیت شما، ممکن است محتوای اضافی دیگری در آنجا ببینید، اما این یک مخزن تازه‌ساخته‌شده با دستور `git init` است — همان چیزی که به‌طور پیش‌فرض می‌بینید.
+فایل `description` تنها توسط برنامه‌ی GitWeb استفاده می‌شود، پس نگران آن نباشید.
+فایل `config` شامل گزینه‌های پیکربندی مخصوص پروژه‌ی شماست و دایرکتوری `info` یک فایل استثنا (global exclude) نگه می‌دارد برای الگوهای نادیده‌گرفتن که نمی‌خواهید در فایل `.gitignore` پی‌گیری شوند.
+دایرکتوری `hooks` اسکریپت‌های هوک سمت کلاینت یا سرور شما را در خود دارد که به‌صورت مفصل در <<ch08-customizing-git#_git_hooks>> توضیح داده شده‌اند.
 
-This leaves four important entries: the `HEAD` and (yet to be created) `index` files, and the `objects` and `refs` directories.
-These are the core parts of Git.
-The `objects` directory stores all the content for your database, the `refs` directory stores pointers into commit objects in that data (branches, tags, remotes and more), the `HEAD` file points to the branch you currently have checked out, and the `index` file is where Git stores your staging area information.
-You'll now look at each of these sections in detail to see how Git operates.
+این‌جا چهار ورودی مهم باقی می‌ماند: فایل‌های `HEAD` و (هنوز ساخته‌نشده) `index`، و دایرکتوری‌های `objects` و `refs`.
+این‌ها اجزای اصلی گیت هستند.
+دایرکتوری `objects` تمام محتوای پایگاه داده‌ی شما را ذخیره می‌کند، دایرکتوری `refs` اشاره‌گرهایی به آبجکت‌های commit در آن داده‌ها را نگه می‌دارد (شاخه‌ها، تگ‌ها، ریموت‌ها و غیره)، فایل `HEAD` به شاخه‌ای که در حال حاضر چک‌اوت شده اشاره می‌کند، و فایل `index` جایی است که گیت اطلاعات ناحیه‌ی آماده‌سازی (staging area) را در آن ذخیره می‌کند.
+اکنون هر یک از این بخش‌ها را با جزئیات بیشتری بررسی خواهید کرد تا ببینید گیت چگونه کار می‌کند.

--- a/book/10-git-internals/sections/refs.asc
+++ b/book/10-git-internals/sections/refs.asc
@@ -1,11 +1,11 @@
 [[_git_refs]]
-=== Git References
+=== Git References (مراجع گیت)
 
-If you were interested in seeing the history of your repository reachable from commit, say, `1a410e`, you could run something like `git log 1a410e` to display that history, but you would still have to remember that `1a410e` is the commit you want to use as the starting point for that history.
-Instead, it would be easier if you had a file in which you could store that SHA-1 value under a simple name so you could use that simple name rather than the raw SHA-1 value.
+اگر می‌خواستید تاریخچه‌ی مخزن خود را از یک کمیت مشخص، مثلاً `1a410e`، ببینید، می‌توانستید چیزی مثل `git log 1a410e` را اجرا کنید تا آن تاریخچه را نمایش دهد، اما در این حالت باید به خاطر می‌سپردید که `1a410e` همان کمیتی است که می‌خواهید به‌عنوان نقطه‌ی شروع آن تاریخچه استفاده کنید.
+به‌جای آن، راحت‌تر است اگر فایلی داشته باشید که بتوانید آن مقدار SHA-1 را تحت یک نام ساده ذخیره کنید تا بتوانید از آن نام ساده به‌جای مقدار خام SHA-1 استفاده کنید.
 
-In Git, these simple names are called "`references`" or "`refs`"; you can find the files that contain those SHA-1 values in the `.git/refs` directory.
-In the current project, this directory contains no files, but it does contain a simple structure:
+در گیت، این نام‌های ساده «مراجع» یا "`refs`" نامیده می‌شوند؛ فایل‌هایی که آن مقادیر SHA-1 را نگه می‌دارند را می‌توانید در دایرکتوری `.git/refs` پیدا کنید.
+در پروژه‌ی فعلی، این دایرکتوری فاقد فایل است، اما یک ساختار ساده دارد:
 
 [source,console]
 ----
@@ -16,14 +16,14 @@ $ find .git/refs
 $ find .git/refs -type f
 ----
 
-To create a new reference that will help you remember where your latest commit is, you can technically do something as simple as this:
+برای ساختن یک مرجع جدید که به شما کمک کند محل آخرین کمییتان را به‌خاطر بسپارید، فنی‌ترین کارِ ممکن می‌تواند چیزی به این سادگی باشد:
 
 [source,console]
 ----
 $ echo 1a410efbd13591db07496601ebc7a059dd55cfe9 > .git/refs/heads/master
 ----
 
-Now, you can use the head reference you just created instead of the SHA-1 value in your Git commands:
+حال می‌توانید به‌جای مقدار SHA-1 در دستورات گیت از مرجع head که همین الآن ساخته‌اید استفاده کنید:
 
 [source,console]
 ----
@@ -33,22 +33,22 @@ cac0cab538b970a37ea1e769cbbde608743bc96d Second commit
 fdf4fc3344e67ab068f836878b6c4951e3b15f3d First commit
 ----
 
-You aren't encouraged to directly edit the reference files; instead, Git provides the safer command `git update-ref` to do this if you want to update a reference:
+تشویق نمی‌شوید که فایل‌های مرجع را مستقیماً ویرایش کنید؛ به‌جای آن، گیت دستور امن‌تری به‌نام `git update-ref` را فراهم می‌کند تا اگر خواستید یک مرجع را به‌روزرسانی کنید از آن استفاده کنید:
 
 [source,console]
 ----
 $ git update-ref refs/heads/master 1a410efbd13591db07496601ebc7a059dd55cfe9
 ----
 
-That's basically what a branch in Git is: a simple pointer or reference to the head of a line of work.
-To create a branch back at the second commit, you can do this:
+در واقع، این همان چیزی است که شاخه (branch) در گیت هست: یک اشاره‌گر یا مرجع ساده به سرِ یک خط کاری.
+برای ایجاد شاخه‌ای بر روی کمییت دوم، می‌توانید این کار را انجام دهید:
 
 [source,console]
 ----
 $ git update-ref refs/heads/test cac0ca
 ----
 
-Your branch will contain only work from that commit down:
+شاخه‌ی شما فقط شامل کار از آن کمییت به بعد خواهد بود:
 
 [source,console]
 ----
@@ -57,26 +57,26 @@ cac0cab538b970a37ea1e769cbbde608743bc96d Second commit
 fdf4fc3344e67ab068f836878b6c4951e3b15f3d First commit
 ----
 
-Now, your Git database conceptually looks something like this:
+حالا، پایگاه‌داده‌ی گیت شما از نظر مفهومی چیزی شبیه به این به‌نظر می‌رسد:
 
 .Git directory objects with branch head references included
 image::images/data-model-4.png[Git directory objects with branch head references included]
 
-When you run commands like `git branch <branch>`, Git basically runs that `update-ref` command to add the SHA-1 of the last commit of the branch you're on into whatever new reference you want to create.
+وقتی دستوراتی مثل `git branch <branch>` را اجرا می‌کنید، گیت اساساً همان دستور `update-ref` را اجرا می‌کند تا SHA-1 آخرین کمییت شاخه‌ای که روی آن هستید را در هر مرجع جدیدی که می‌خواهید ایجاد کنید قرار دهد.
 
 [[ref_the_ref]]
-==== The HEAD
+==== The HEAD (نشانگر)
 
-The question now is, when you run `git branch <branch>`, how does Git know the SHA-1 of the last commit?
-The answer is the HEAD file.
+سؤال این است که وقتی `git branch <branch>` را اجرا می‌کنید، گیت چگونه SHA-1 آخرین کمییت را می‌داند؟
+پاسخ فایل HEAD است.
 
-Usually the HEAD file is a symbolic reference to the branch you're currently on.
-By symbolic reference, we mean that unlike a normal reference, it contains a pointer to another reference.
+معمولاً فایل HEAD یک مرجع نمادین (symbolic reference) به شاخه‌ای است که در حال حاضر روی آن قرار دارید.
+منظور از مرجع نمادین این است که برخلاف یک مرجع معمولی، این فایل حاوی اشاره‌ای به یک مرجع دیگر است.
 
-However in some rare cases the HEAD file may contain the SHA-1 value of a Git object.
-This happens when you checkout a tag, commit, or remote branch, which puts your repository in https://git-scm.com/docs/git-checkout#_detached_head["detached HEAD"^] state.
+ با این حال در برخی موارد نادر، فایل HEAD ممکن است حاوی مقدار SHA-1 یک شیء Git باشد.
+این زمانی اتفاق می‌افتد که شما یک تگ، کامیت یا شاخهٔ ریموت را checkout می‌کنید، که مخزن شما را در وضعیت "detached HEAD" قرار می‌دهد.
 
-If you look at the file, you'll normally see something like this:
+اگر به محتویات این فایل نگاه کنید، معمولاً چیزی شبیهِ این خواهید دید:
 
 [source,console]
 ----
@@ -84,7 +84,7 @@ $ cat .git/HEAD
 ref: refs/heads/master
 ----
 
-If you run `git checkout test`, Git updates the file to look like this:
+اگر دستور `git checkout test` را اجرا کنید، Git این فایل را به این شکل به‌روزرسانی می‌کند:
 
 [source,console]
 ----
@@ -92,10 +92,10 @@ $ cat .git/HEAD
 ref: refs/heads/test
 ----
 
-When you run `git commit`, it creates the commit object, specifying the parent of that commit object to be whatever SHA-1 value the reference in HEAD points to.
+وقتی که `git commit` را اجرا می‌کنید، یک شیء کامیت ساخته می‌شود و والد آن شیء کامیت، مقداری SHA-1 خواهد بود که مرجع در HEAD به آن اشاره می‌کند.
 
-You can also manually edit this file, but again a safer command exists to do so: `git symbolic-ref`.
-You can read the value of your HEAD via this command:
+شما همچنین می‌توانید این فایل را دستی ویرایش کنید، اما باز هم یک فرمان ایمن‌تر برای این کار وجود دارد: `git symbolic-ref`.
+می‌توانید مقدار HEAD را با استفاده از این فرمان بخوانید:
 
 [source,console]
 ----
@@ -103,7 +103,7 @@ $ git symbolic-ref HEAD
 refs/heads/master
 ----
 
-You can also set the value of HEAD using the same command:
+همچنین می‌توانید مقدار HEAD را با همان فرمان تنظیم کنید:
 
 [source,console]
 ----
@@ -112,7 +112,7 @@ $ cat .git/HEAD
 ref: refs/heads/test
 ----
 
-You can't set a symbolic reference outside of the refs style:
+نمی‌توانید یک ارجاع نمادین را خارج از سبک refs قرار دهید:
 
 [source,console]
 ----
@@ -120,32 +120,33 @@ $ git symbolic-ref HEAD test
 fatal: Refusing to point HEAD outside of refs/
 ----
 
-==== Tags
+==== Tags (تگ‌ها)
 
-We just finished discussing Git's three main object types (_blobs_, _trees_ and _commits_), but there is a fourth.
-The _tag_ object is very much like a commit object -- it contains a tagger, a date, a message, and a pointer.
-The main difference is that a tag object generally points to a commit rather than a tree.
-It's like a branch reference, but it never moves -- it always points to the same commit but gives it a friendlier name.
+همین‌الان دربارهٔ سه نوع اصلی اشیاء Git (_blob_ها، _tree_ها و _commit_ها) صحبت کردیم، اما یک نوع چهارم هم وجود دارد.
+شیء tag بسیار شبیه به شیء commit است — شامل اطلاعات تگ‌زننده (tagger)، تاریخ، پیغام و یک نشانگر است.
+تفاوت اصلی این است که یک شیء تگ معمولاً به یک commit اشاره می‌کند تا به یک tree.
+این مانند یک ارجاع شاخه است، اما هرگز حرکت نمی‌کند — همیشه به همان کامیت اشاره می‌کند و برای آن نامی دوستانه‌تر فراهم می‌آورد.
 
-As discussed in <<ch02-git-basics-chapter#ch02-git-basics-chapter>>, there are two types of tags: annotated and lightweight.
-You can make a lightweight tag by running something like this:
+همان‌طور که در <<ch02-git-basics-chapter#ch02-git-basics-chapter>> توضیح داده شد، دو نوع **tag** وجود دارد:
+**annotated** و **lightweight**.
+برای ساخت یک **lightweight tag** می‌توانید چیزی شبیه به این اجرا کنید:
 
 [source,console]
 ----
 $ git update-ref refs/tags/v1.0 cac0cab538b970a37ea1e769cbbde608743bc96d
 ----
 
-That is all a lightweight tag is -- a reference that never moves.
-An annotated tag is more complex, however.
-If you create an annotated tag, Git creates a tag object and then writes a reference to point to it rather than directly to the commit.
-You can see this by creating an annotated tag (using the `-a` option):
+این تمام چیزی است که یک **lightweight tag** هست — یک **reference** که هیچ‌وقت جابه‌جا نمی‌شود.
+اما یک **annotated tag** کمی پیچیده‌تر است.
+وقتی یک **annotated tag** می‌سازید، Git یک **tag object** ایجاد می‌کند و سپس یک **reference** می‌نویسد تا به آن اشاره کند، به‌جای اینکه مستقیماً به **commit** اشاره داشته باشد.
+می‌توانید این موضوع را با ساخت یک **annotated tag** (با استفاده از گزینه‌ی `-a`) ببینید:
 
 [source,console]
 ----
 $ git tag -a v1.1 1a410efbd13591db07496601ebc7a059dd55cfe9 -m 'Test tag'
 ----
 
-Here's the object SHA-1 value it created:
+اینجا مقدار **SHA-1 object** ساخته‌شده را می‌بینید:
 
 [source,console]
 ----
@@ -153,7 +154,7 @@ $ cat .git/refs/tags/v1.1
 9585191f37f7b0fb9444f35a9bf50de191beadc2
 ----
 
-Now, run `git cat-file -p` on that SHA-1 value:
+حالا دستور `git cat-file -p` را روی آن مقدار **SHA-1** اجرا کنید:
 
 [source,console]
 ----
@@ -166,23 +167,23 @@ tagger Scott Chacon <schacon@gmail.com> Sat May 23 16:48:58 2009 -0700
 Test tag
 ----
 
-Notice that the object entry points to the commit SHA-1 value that you tagged.
-Also notice that it doesn't need to point to a commit; you can tag any Git object.
-In the Git source code, for example, the maintainer has added their GPG public key as a blob object and then tagged it.
-You can view the public key by running this in a clone of the Git repository:
+توجه کنید که این **object entry** به مقدار **SHA-1 commit** که شما تگ زده‌اید اشاره می‌کند.
+همچنین توجه داشته باشید که نیازی نیست حتماً به یک **commit** اشاره کند؛ شما می‌توانید هر **Git object** را تگ بزنید.
+برای مثال، در **Git source code**، نگه‌دارنده (maintainer) کلید عمومی **GPG** خودش را به‌عنوان یک **blob object** اضافه کرده و سپس آن را تگ زده است.
+می‌توانید کلید عمومی را با اجرای این دستور در یک **clone** از مخزن Git ببینید:
 
 [source,console]
 ----
 $ git cat-file blob junio-gpg-pub
 ----
 
-The Linux kernel repository also has a non-commit-pointing tag object -- the first tag created points to the initial tree of the import of the source code.
+مخزن **Linux kernel** نیز یک **tag object** دارد که به یک **commit** اشاره نمی‌کند — اولین **tag** ساخته‌شده به **initial tree** واردشده از **source code** اشاره دارد.
 
-==== Remotes
+==== Remotes (ریموت ها)
 
-The third type of reference that you'll see is a remote reference.
-If you add a remote and push to it, Git stores the value you last pushed to that remote for each branch in the `refs/remotes` directory.
-For instance, you can add a remote called `origin` and push your `master` branch to it:
+سومین نوع **reference** که خواهید دید، یک **remote reference** است.
+اگر یک **remote** اضافه کنید و به آن **push** کنید، Git آخرین مقداری که به آن **remote** برای هر **branch** فرستاده‌اید را در مسیر `refs/remotes` ذخیره می‌کند.
+برای مثال، می‌توانید یک **remote** به نام `origin` اضافه کنید و **branch** `master` را به آن **push** کنید:
 
 [source,console]
 ----
@@ -196,7 +197,7 @@ To git@github.com:schacon/simplegit-progit.git
   a11bef0..ca82a6d  master -> master
 ----
 
-Then, you can see what the `master` branch on the `origin` remote was the last time you communicated with the server, by checking the `refs/remotes/origin/master` file:
+سپس می‌توانید ببینید که آخرین بار **branch** `master` روی **remote** `origin` چه بوده، با بررسی فایل `refs/remotes/origin/master`:
 
 [source,console]
 ----
@@ -204,6 +205,6 @@ $ cat .git/refs/remotes/origin/master
 ca82a6dff817ec66f44342007202690a93763949
 ----
 
-Remote references differ from branches (`refs/heads` references) mainly in that they're considered read-only.
-You can `git checkout` to one, but Git won't symbolically reference HEAD to one, so you'll never update it with a `commit` command.
-Git manages them as bookmarks to the last known state of where those branches were on those servers.
+تفاوت اصلی **remote references** با **branches** (یعنی **refs/heads**) در این است که آن‌ها فقط-خواندنی (**read-only**) در نظر گرفته می‌شوند.
+شما می‌توانید به یکی از آن‌ها `git checkout` کنید، اما Git هرگز **HEAD** را به‌صورت سمبولیک به آن‌ها ارجاع نمی‌دهد، بنابراین هیچ‌وقت با دستور `commit` به‌روزرسانی نمی‌شوند.
+Git آن‌ها را مثل **bookmark**‌هایی مدیریت می‌کند که نشان‌دهنده آخرین وضعیت شناخته‌شده از آن **branches** روی آن **servers** هستند.

--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -1,15 +1,15 @@
 [[_refspec]]
-=== The Refspec
+=== The Refspec (نگاشت)
 
-Throughout this book, we've used simple mappings from remote branches to local references, but they can be more complex.
-Suppose you were following along with the last couple sections and had created a small local Git repository, and now wanted to add a _remote_ to it:
+در سراسر این کتاب، ما از نگاشت‌های ساده بین **remote branches** و **local references** استفاده کرده‌ایم، اما این نگاشت‌ها می‌توانند پیچیده‌تر باشند.
+فرض کنید مراحل چند بخش قبلی را دنبال کرده‌اید و یک مخزن محلی کوچک Git ساخته‌اید و حالا می‌خواهید یک **remote** به آن اضافه کنید:
 
 [source,console]
 ----
 $ git remote add origin https://github.com/schacon/simplegit-progit
 ----
 
-Running the command above adds a section to your repository's `.git/config` file, specifying the name of the remote (`origin`), the URL of the remote repository, and the _refspec_ to be used for fetching:
+اجرای دستور بالا بخشی به فایل `.git/config` مخزن شما اضافه می‌کند که نام **remote** (`origin`)، آدرس **URL** مخزن ریموت و **refspec** مورد استفاده برای **fetching** را مشخص می‌کند:
 
 [source,ini]
 ----
@@ -18,11 +18,12 @@ Running the command above adds a section to your repository's `.git/config` file
 	fetch = +refs/heads/*:refs/remotes/origin/*
 ----
 
-The format of the refspec is, first, an optional `+`, followed by `<src>:<dst>`, where `<src>` is the pattern for references on the remote side and `<dst>` is where those references will be tracked locally.
-The `+` tells Git to update the reference even if it isn't a fast-forward.
+فرمت **refspec** به این صورت است: ابتدا یک `+` اختیاری، و سپس `<src>:<dst>`.
+در اینجا `<src>` الگوی **references** در سمت ریموت است و `<dst>` محلی است که آن **references** در آن ردیابی خواهند شد.
+علامت `+` به Git می‌گوید که **reference** را حتی اگر **fast-forward** نباشد، به‌روزرسانی کند.
 
-In the default case that is automatically written by a `git remote add origin` command, Git fetches all the references under `refs/heads/` on the server and writes them to `refs/remotes/origin/` locally.
-So, if there is a `master` branch on the server, you can access the log of that branch locally via any of the following:
+در حالت پیش‌فرض که به‌طور خودکار توسط دستور `git remote add origin` نوشته می‌شود، Git تمام **references** زیر مسیر `refs/heads/` روی سرور را دریافت کرده و آن‌ها را به `refs/remotes/origin/` در سیستم محلی می‌نویسد.
+بنابراین، اگر روی سرور یک **branch** به نام `master` وجود داشته باشد، شما می‌توانید لاگ آن **branch** را به‌صورت محلی از طریق هر یک از مسیرهای زیر مشاهده کنید:
 
 [source,console]
 ----
@@ -31,26 +32,26 @@ $ git log remotes/origin/master
 $ git log refs/remotes/origin/master
 ----
 
-They're all equivalent, because Git expands each of them to `refs/remotes/origin/master`.
+همه آن‌ها معادل هستند، چون Git همه آن‌ها را به `refs/remotes/origin/master` بسط می‌دهد.
 
-If you want Git instead to pull down only the `master` branch each time, and not every other branch on the remote server, you can change the fetch line to refer to that branch only:
+اگر بخواهید Git فقط **branch** `master` را هر بار دریافت کند (و نه همه **branches** روی سرور ریموت)، می‌توانید خط مربوط به **fetch** را تغییر دهید تا فقط به همان **branch** اشاره کند:
 
 [source]
 ----
 fetch = +refs/heads/master:refs/remotes/origin/master
 ----
 
-This is just the default refspec for `git fetch` for that remote.
-If you want to do a one-time only fetch, you can specify the specific refspec on the command line, too.
-To pull the `master` branch on the remote down to `origin/mymaster` locally, you can run:
+این فقط **refspec** پیش‌فرض برای `git fetch` آن **remote** است.
+اگر بخواهید تنها یک بار این کار را انجام دهید، می‌توانید **refspec** موردنظر را مستقیم در خط فرمان مشخص کنید.
+برای کشیدن **branch** `master` از ریموت و ذخیره آن به‌عنوان `origin/mymaster` محلی، می‌توانید اجرا کنید:
 
 [source,console]
 ----
 $ git fetch origin master:refs/remotes/origin/mymaster
 ----
 
-You can also specify multiple refspecs.
-On the command line, you can pull down several branches like so:
+شما همچنین می‌توانید چندین **refspec** مشخص کنید.
+روی خط فرمان می‌توانید چند **branch** را این‌طور دریافت کنید:
 
 [source,console]
 ----
@@ -61,11 +62,11 @@ From git@github.com:schacon/simplegit
  * [new branch]      topic      -> origin/topic
 ----
 
-In this case, the `master` branch pull was rejected because it wasn't listed as a fast-forward reference.
-You can override that by specifying the `+` in front of the refspec.
+در این حالت، **pull** مربوط به **branch** `master` رد شد چون به‌عنوان یک **fast-forward reference** لیست نشده بود.
+می‌توانید با اضافه کردن `+` جلوی **refspec** آن را مجبور به انجام کنید.
 
-You can also specify multiple refspecs for fetching in your configuration file.
-If you want to always fetch the `master` and `experiment` branches from the `origin` remote, add two lines:
+شما همچنین می‌توانید چندین **refspec** برای **fetching** در فایل **configuration** تعریف کنید.
+اگر بخواهید همیشه **branches** `master` و `experiment` را از **remote** به نام `origin` دریافت کنید، باید دو خط اضافه کنید:
 
 [source,ini]
 ----
@@ -75,15 +76,15 @@ If you want to always fetch the `master` and `experiment` branches from the `ori
 	fetch = +refs/heads/experiment:refs/remotes/origin/experiment
 ----
 
-Since Git 2.6.0 you can use partial globs in the pattern to match multiple branches, so this works:
+از Git نسخه 2.6.0 به بعد می‌توانید از **partial globs** در الگوها استفاده کنید تا چند **branch** را همزمان انتخاب کنید، مثلاً:
 
 [source,ini]
 ----
 fetch = +refs/heads/qa*:refs/remotes/origin/qa*
 ----
 
-Even better, you can use namespaces (or directories) to accomplish the same with more structure.
-If you have a QA team that pushes a series of branches, and you want to get the `master` branch and any of the QA team's branches but nothing else, you can use a config section like this:
+حتی بهتر اینکه می‌توانید از **namespaces (یا directories)** برای رسیدن به همین نتیجه به شکلی ساخت‌یافته‌تر استفاده کنید.
+اگر تیم QA تعدادی **branches** را **push** کند و شما بخواهید **branch** `master` و همه **branches** آن تیم QA را دریافت کنید (و هیچ چیز دیگری)، می‌توانید بخشی از تنظیمات خود را این‌طور تعریف کنید:
 
 [source,ini]
 ----
@@ -93,22 +94,22 @@ If you have a QA team that pushes a series of branches, and you want to get the 
 	fetch = +refs/heads/qa/*:refs/remotes/origin/qa/*
 ----
 
-If you have a complex workflow process that has a QA team pushing branches, developers pushing branches, and integration teams pushing and collaborating on remote branches, you can namespace them easily this way.
+اگر یک فرآیند کاری پیچیده داشته باشید که در آن تیم QA، تیم توسعه‌دهنده‌ها و تیم یکپارچه‌سازی هر کدام **branches** خودشان را **push** کنند و روی **remote branches** همکاری داشته باشند، با این روش می‌توانید خیلی راحت آن‌ها را با **namespace** مدیریت کنید.
 
 [[_pushing_refspecs]]
-==== Pushing Refspecs
+==== Pushing Refspecs (نگاشت‌های پوش)
 
-It's nice that you can fetch namespaced references that way, but how does the QA team get their branches into a `qa/` namespace in the first place?
-You accomplish that by using refspecs to push.
+این عالی است که می‌توانید **namespaced references** را این‌طور دریافت کنید، اما تیم QA چطور باید **branches** خودشان را درون یک فضای `qa/` روی سرور قرار دهند؟
+این کار با استفاده از **refspecs** هنگام **push** انجام می‌شود.
 
-If the QA team wants to push their `master` branch to `qa/master` on the remote server, they can run:
+اگر تیم QA بخواهد **branch** `master` خودش را به `qa/master` روی سرور **push** کند، می‌تواند اجرا کند:
 
 [source,console]
 ----
 $ git push origin master:refs/heads/qa/master
 ----
 
-If they want Git to do that automatically each time they run `git push origin`, they can add a `push` value to their config file:
+اگر بخواهند Git این کار را به‌صورت خودکار هر بار که `git push origin` اجرا می‌شود انجام دهد، می‌توانند یک مقدار **push** در فایل تنظیمات اضافه کنند:
 
 [source,ini]
 ----
@@ -118,26 +119,26 @@ If they want Git to do that automatically each time they run `git push origin`, 
 	push = refs/heads/master:refs/heads/qa/master
 ----
 
-Again, this will cause a `git push origin` to push the local `master` branch to the remote `qa/master` branch by default.
+در این صورت، اجرای `git push origin` باعث می‌شود که **branch** محلی `master` به **branch** `qa/master` روی سرور **push** شود.
 
 [NOTE]
 ====
-You cannot use the refspec to fetch from one repository and push to another one.
-For an example to do so, refer to <<ch06-github#_fetch_and_push_on_different_repositories>>.
+شما نمی‌توانید از **refspec** برای **fetch** از یک مخزن و **push** به مخزن دیگری استفاده کنید.
+برای نمونه‌ای از این کار، به <<ch06-github#_fetch_and_push_on_different_repositories>> مراجعه کنید.
 ====
 
 ==== Deleting References
 
-You can also use the refspec to delete references from the remote server by running something like this:
+همچنین می‌توانید از **refspec** برای حذف **references** از روی سرور ریموت استفاده کنید، با اجرای چیزی شبیه این:
 
 [source,console]
 ----
 $ git push origin :topic
 ----
 
-Because the refspec is `<src>:<dst>`, by leaving off the `<src>` part, this basically says to make the `topic` branch on the remote nothing, which deletes it.
+از آنجایی که فرمت **refspec** به صورت `<src>:<dst>` است، وقتی بخش `<src>` را حذف کنید، در واقع می‌گویید که **branch** `topic` روی ریموت هیچ چیزی نباشد، و این باعث حذف آن می‌شود.
 
-Or you can use the newer syntax (available since Git v1.7.0):
+یا می‌توانید از دستور جدیدتر (که از Git نسخه v1.7.0 به بعد در دسترس است) استفاده کنید:
 
 [source,console]
 ----

--- a/book/10-git-internals/sections/transfer-protocols.asc
+++ b/book/10-git-internals/sections/transfer-protocols.asc
@@ -1,29 +1,29 @@
-=== Transfer Protocols
+=== Transfer Protocols (پروتکل‌های انتقال)
 
-Git can transfer data between two repositories in two major ways: the "`dumb`" protocol and the "`smart`" protocol.
-This section will quickly cover how these two main protocols operate.
+Git می‌تواند داده‌ها را بین دو **repository** به دو روش اصلی منتقل کند: پروتکل "`dumb`" و پروتکل "`smart`".
+این بخش به‌طور سریع توضیح می‌دهد که این دو پروتکل اصلی چطور عمل می‌کنند.
 
-==== The Dumb Protocol
+==== The Dumb Protocol (پروتکل ساده)
 
-If you're setting up a repository to be served read-only over HTTP, the dumb protocol is likely what will be used.
-This protocol is called "`dumb`" because it requires no Git-specific code on the server side during the transport process; the fetch process is a series of HTTP `GET` requests, where the client can assume the layout of the Git repository on the server.
+اگر می‌خواهید یک **repository** را فقط به صورت **read-only** از طریق **HTTP** سرو کنید، به احتمال زیاد از پروتکل **dumb** استفاده می‌شود.
+به این پروتکل "`dumb`" گفته می‌شود چون در سمت سرور هیچ کد اختصاصی مربوط به Git در طول فرآیند انتقال نیاز ندارد؛ فرآیند **fetch** مجموعه‌ای از درخواست‌های **HTTP GET** است که در آن کلاینت می‌تواند ساختار **repository** روی سرور را فرض بگیرد.
 
 [NOTE]
 ====
-The dumb protocol is fairly rarely used these days.
-It's difficult to secure or make private, so most Git hosts (both cloud-based and on-premises) will refuse to use it.
-It's generally advised to use the smart protocol, which we describe a bit further on.
+این پروتکل امروزه بسیار به‌ندرت استفاده می‌شود.
+ایمن‌سازی یا خصوصی‌سازی آن سخت است، به همین دلیل بیشتر میزبان‌های Git (چه ابری و چه on-premises) استفاده از آن را رد می‌کنند.
+به‌طور کلی توصیه می‌شود از پروتکل **smart** استفاده کنید که کمی جلوتر توضیح داده می‌شود.
 ====
 
-Let's follow the `http-fetch` process for the simplegit library:
+بیایید فرآیند `http-fetch` برای کتابخانه **simplegit** را دنبال کنیم:
 
 [source,console]
 ----
 $ git clone http://server/simplegit-progit.git
 ----
 
-The first thing this command does is pull down the `info/refs` file.
-This file is written by the `update-server-info` command, which is why you need to enable that as a `post-receive` hook in order for the HTTP transport to work properly:
+اولین کاری که این دستور انجام می‌دهد، دریافت فایل `info/refs` است.
+این فایل توسط دستور `update-server-info` نوشته می‌شود، به همین دلیل باید آن را به‌عنوان یک **post-receive hook** فعال کنید تا انتقال HTTP به‌درستی کار کند:
 
 [source]
 ----
@@ -31,8 +31,8 @@ This file is written by the `update-server-info` command, which is why you need 
 ca82a6dff817ec66f44342007202690a93763949     refs/heads/master
 ----
 
-Now you have a list of the remote references and SHA-1s.
-Next, you look for what the HEAD reference is so you know what to check out when you're finished:
+حالا لیستی از **remote references** و مقادیر **SHA-1** دارید.
+سپس بررسی می‌کنید که **HEAD reference** چیست تا بدانید در پایان باید چه چیزی را **checkout** کنید:
 
 [source]
 ----
@@ -40,9 +40,9 @@ Next, you look for what the HEAD reference is so you know what to check out when
 ref: refs/heads/master
 ----
 
-You need to check out the `master` branch when you've completed the process.
-At this point, you're ready to start the walking process.
-Because your starting point is the `ca82a6` commit object you saw in the `info/refs` file, you start by fetching that:
+در اینجا باید پس از پایان فرآیند، **branch** `master` را **checkout** کنید.
+اکنون آماده شروع فرآیند **walking** هستید.
+از آنجا که نقطه شروع شما همان **commit object** `ca82a6` است که در فایل `info/refs` دیدید، کار را با دریافت آن آغاز می‌کنید:
 
 [source]
 ----
@@ -50,8 +50,8 @@ Because your starting point is the `ca82a6` commit object you saw in the `info/r
 (179 bytes of binary data)
 ----
 
-You get an object back – that object is in loose format on the server, and you fetched it over a static HTTP GET request.
-You can zlib-uncompress it, strip off the header, and look at the commit content:
+یک **object** دریافت می‌کنید – این **object** روی سرور به صورت **loose format** است و شما آن را از طریق یک درخواست ساده **HTTP GET** گرفته‌اید.
+می‌توانید آن را با zlib از حالت فشرده خارج کنید، **header** را جدا کنید و محتوای **commit** را ببینید:
 
 [source,console]
 ----
@@ -64,7 +64,7 @@ committer Scott Chacon <schacon@gmail.com> 1240030591 -0700
 Change version number
 ----
 
-Next, you have two more objects to retrieve – `cfda3b`, which is the tree of content that the commit we just retrieved points to; and `085bb3`, which is the parent commit:
+سپس باید دو **object** دیگر دریافت کنید: `cfda3b` که **tree of content** مربوط به **commit** است، و `085bb3` که **parent commit** است:
 
 [source]
 ----
@@ -72,8 +72,8 @@ Next, you have two more objects to retrieve – `cfda3b`, which is the tree of c
 (179 bytes of data)
 ----
 
-That gives you your next commit object.
-Grab the tree object:
+اینجا **commit object** بعدی را دارید.
+حالا **tree object** را بگیرید:
 
 [source]
 ----
@@ -81,9 +81,9 @@ Grab the tree object:
 (404 - Not Found)
 ----
 
-Oops – it looks like that tree object isn't in loose format on the server, so you get a 404 response back.
-There are a couple of reasons for this – the object could be in an alternate repository, or it could be in a packfile in this repository.
-Git checks for any listed alternates first:
+اوه – به‌نظر می‌رسد این **tree object** روی سرور به صورت **loose format** نیست، بنابراین پاسخ 404 دریافت می‌کنید.
+دلایل احتمالی این موضوع: **object** ممکن است در یک **alternate repository** باشد یا در یک **packfile** در همین مخزن.
+Git ابتدا وجود هر **alternate** را بررسی می‌کند:
 
 [source]
 ----
@@ -91,9 +91,9 @@ Git checks for any listed alternates first:
 (empty file)
 ----
 
-If this comes back with a list of alternate URLs, Git checks for loose files and packfiles there – this is a nice mechanism for projects that are forks of one another to share objects on disk.
-However, because no alternates are listed in this case, your object must be in a packfile.
-To see what packfiles are available on this server, you need to get the `objects/info/packs` file, which contains a listing of them (also generated by `update-server-info`):
+اگر لیستی از آدرس‌های **alternate** برگردانده شود، Git در آن‌ها به دنبال **loose files** و **packfiles** می‌گردد – این مکانیزم خوبی برای پروژه‌هایی است که **fork** یکدیگر هستند تا روی دیسک **objects** را به‌اشتراک بگذارند.
+اما چون اینجا هیچ **alternate**‌ای لیست نشده، **object** شما باید در یک **packfile** باشد.
+برای دیدن اینکه چه **packfiles** روی سرور موجود است، باید فایل `objects/info/packs` را بگیرید که لیستی از آن‌ها را دارد (این هم توسط `update-server-info` تولید می‌شود):
 
 [source]
 ----
@@ -101,8 +101,8 @@ To see what packfiles are available on this server, you need to get the `objects
 P pack-816a9b2334da9953e530f27bcac22082a9f5b835.pack
 ----
 
-There is only one packfile on the server, so your object is obviously in there, but you'll check the index file to make sure.
-This is also useful if you have multiple packfiles on the server, so you can see which packfile contains the object you need:
+روی سرور فقط یک **packfile** وجود دارد، پس مشخص است **object** شما داخل آن است، اما باید **index file** را بررسی کنید تا مطمئن شوید.
+این بررسی همچنین زمانی مفید است که چندین **packfile** روی سرور وجود داشته باشد تا بفهمید کدام یک شامل **object** موردنظر شما است:
 
 [source]
 ----
@@ -110,8 +110,8 @@ This is also useful if you have multiple packfiles on the server, so you can see
 (4k of binary data)
 ----
 
-Now that you have the packfile index, you can see if your object is in it – because the index lists the SHA-1s of the objects contained in the packfile and the offsets to those objects.
-Your object is there, so go ahead and get the whole packfile:
+حالا که **packfile index** را دارید، می‌توانید ببینید که آیا **object** شما در آن وجود دارد یا نه – چون این **index** لیست **SHA-1s** مربوط به **objects** موجود در **packfile** و آدرس‌های آن‌ها را دارد.
+چون **object** شما در آن وجود دارد، کل **packfile** را دریافت کنید:
 
 [source]
 ----
@@ -119,27 +119,25 @@ Your object is there, so go ahead and get the whole packfile:
 (13k of binary data)
 ----
 
-You have your tree object, so you continue walking your commits.
-They're all also within the packfile you just downloaded, so you don't have to do any more requests to your server.
-Git checks out a working copy of the `master` branch that was pointed to by the HEAD reference you downloaded at the beginning.
+حالا **tree object** را دارید، پس ادامه می‌دهید و **commits** خود را پیمایش می‌کنید.
+همه آن‌ها نیز داخل همان **packfile** هستند، بنابراین نیازی به درخواست‌های بیشتر به سرور نیست.
+Git یک **working copy** از **branch** `master` که در ابتدای کار توسط **HEAD reference** مشخص شد، **checkout** می‌کند.
 
-==== The Smart Protocol
+==== The Smart Protocol (پروتکل هوشمند)
 
-The dumb protocol is simple but a bit inefficient, and it can't handle writing of data from the client to the server.
-The smart protocol is a more common method of transferring data, but it requires a process on the remote end that is intelligent about Git – it can read local data, figure out what the client has and needs, and generate a custom packfile for it.
-There are two sets of processes for transferring data: a pair for uploading data and a pair for downloading data.
+پروتکل **dumb** ساده است اما کمی ناکارآمد بوده و نمی‌تواند داده‌ای از کلاینت به سرور بنویسد.
+پروتکل **smart** روشی رایج‌تر برای انتقال داده است، اما نیاز به پردازشی در سمت ریموت دارد که از Git آگاه باشد – بتواند داده‌های محلی را بخواند، بفهمد کلاینت چه دارد و چه نیاز دارد، و یک **packfile** سفارشی برای آن تولید کند.
+دو مجموعه فرآیند برای انتقال داده وجود دارد: یک جفت برای **uploading data** و یک جفت برای **downloading data**.
 
-===== Uploading Data
+===== Uploading Data (بارگذاری داده)
 
 (((git commands, send-pack)))(((git commands, receive-pack)))
-To upload data to a remote process, Git uses the `send-pack` and `receive-pack` processes.
-The `send-pack` process runs on the client and connects to a `receive-pack` process on the remote side.
+برای **upload data** به یک فرآیند ریموت، Git از فرآیندهای `send-pack` و `receive-pack` استفاده می‌کند.
+فرآیند `send-pack` روی کلاینت اجرا شده و به فرآیند `receive-pack` در سمت ریموت متصل می‌شود.
 
-====== SSH
-
-For example, say you run `git push origin master` in your project, and `origin` is defined as a URL that uses the SSH protocol.
-Git fires up the `send-pack` process, which initiates a connection over SSH to your server.
-It tries to run a command on the remote server via an SSH call that looks something like this:
+====== SSH (پروتکل امن شل)
+برای مثال، اگر شما در پروژه‌تان دستور `git push origin master` را اجرا کنید و `origin` یک آدرس با پروتکل SSH باشد، Git فرآیند `send-pack` را اجرا کرده و یک اتصال **SSH** به سرور برقرار می‌کند.
+سپس سعی می‌کند دستوری روی سرور ریموت اجرا کند که شبیه به این است:
 
 [source,console]
 ----
@@ -150,18 +148,18 @@ $ ssh -x git@server "git-receive-pack 'simplegit-progit.git'"
 0000
 ----
 
-The `git-receive-pack` command immediately responds with one line for each reference it currently has – in this case, just the `master` branch and its SHA-1.
-The first line also has a list of the server's capabilities (here, `report-status`, `delete-refs`, and some others, including the client identifier).
+دستور `git-receive-pack` بلافاصله یک خط برای هر **reference** موجود برمی‌گرداند – در این مثال فقط **branch** `master` و مقدار **SHA-1** آن.
+اولین خط همچنین شامل لیستی از قابلیت‌های سرور است (اینجا: `report-status`, `delete-refs` و چند مورد دیگر از جمله شناسه کلاینت).
 
-The data is transmitted in chunks.
-Each chunk starts with a 4-character hex value specifying how long the chunk is (including the 4 bytes of the length itself).
-Chunks usually contain a single line of data and a trailing linefeed.
-Your first chunk starts with 00a5, which is hexadecimal for 165, meaning the chunk is 165 bytes long.
-The next chunk is 0000, meaning the server is done with its references listing.
+داده‌ها به صورت **chunks** منتقل می‌شوند.
+هر **chunk** با یک مقدار ۴ کاراکتری هگزادسیمال شروع می‌شود که طول **chunk** (شامل همان ۴ بایت اول) را مشخص می‌کند.
+معمولاً هر **chunk** شامل یک خط داده و یک **linefeed** پایانی است.
+اولین **chunk** شما با 00a5 شروع می‌شود که در مبنای هگز برابر با 165 است، یعنی طول **chunk** برابر 165 بایت است.
+**chunk** بعدی 0000 است، یعنی سرور لیست **references** خود را تمام کرده.
 
-Now that it knows the server's state, your `send-pack` process determines what commits it has that the server doesn't.
-For each reference that this push will update, the `send-pack` process tells the `receive-pack` process that information.
-For instance, if you're updating the `master` branch and adding an `experiment` branch, the `send-pack` response may look something like this:
+حالا که وضعیت سرور مشخص شد، فرآیند `send-pack` تعیین می‌کند چه **commits**‌ای دارد که سرور ندارد.
+برای هر **reference** که این **push** قرار است به‌روزرسانی کند، فرآیند `send-pack` آن اطلاعات را به `receive-pack` می‌فرستد.
+برای مثال، اگر شما در حال به‌روزرسانی **branch** `master` و اضافه‌کردن **branch** `experiment` باشید، پاسخ `send-pack` چیزی شبیه به این خواهد بود:
 
 [source]
 ----
@@ -172,23 +170,23 @@ For instance, if you're updating the `master` branch and adding an `experiment` 
 0000
 ----
 
-Git sends a line for each reference you're updating with the line's length, the old SHA-1, the new SHA-1, and the reference that is being updated.
-The first line also has the client's capabilities.
-The SHA-1 value of all '0's means that nothing was there before – because you're adding the `experiment` reference.
-If you were deleting a reference, you would see the opposite: all '0's on the right side.
+Git برای هر **reference** که به‌روزرسانی می‌کنید یک خط می‌فرستد که شامل طول خط، **old SHA-1**، **new SHA-1** و **reference** در حال به‌روزرسانی است.
+اولین خط همچنین قابلیت‌های کلاینت را دارد.
+مقدار **SHA-1** پر از صفر (`0000...`) یعنی قبلاً چیزی وجود نداشته – چون دارید یک **reference** جدید (`experiment`) اضافه می‌کنید.
+اگر در حال حذف یک **reference** باشید، حالت برعکس خواهد بود: سمت راست پر از صفر خواهد بود.
 
-Next, the client sends a packfile of all the objects the server doesn't have yet.
-Finally, the server responds with a success (or failure) indication:
+در مرحله بعد، کلاینت یک **packfile** شامل تمام **objects**ی که سرور ندارد ارسال می‌کند.
+در نهایت، سرور با یک پیام موفقیت (یا شکست) پاسخ می‌دهد:
 
 [source]
 ----
 000eunpack ok
 ----
 
-====== HTTP(S)
+====== HTTP(S) (پروتکل انتقال ابرمتن امن)
 
-This process is mostly the same over HTTP, though the handshaking is a bit different.
-The connection is initiated with this request:
+این فرآیند روی **HTTP** تقریباً مشابه است، فقط **handshaking** کمی متفاوت است.
+اتصال با این درخواست شروع می‌شود:
 
 [source]
 ----
@@ -200,35 +198,35 @@ The connection is initiated with this request:
 0000
 ----
 
-That's the end of the first client-server exchange.
-The client then makes another request, this time a `POST`, with the data that `send-pack` provides.
+این پایان اولین تبادل **client-server** است.
+سپس کلاینت یک درخواست دیگر می‌فرستد، این بار یک **POST**، با داده‌ای که توسط `send-pack` تولید شده:
 
 [source]
 ----
 => POST http://server/simplegit-progit.git/git-receive-pack
 ----
 
-The `POST` request includes the `send-pack` output and the packfile as its payload.
-The server then indicates success or failure with its HTTP response.
+درخواست **POST** شامل خروجی `send-pack` و **packfile** به‌عنوان payload است.
+سرور در پاسخ، موفقیت یا شکست عملیات را مشخص می‌کند.
 
-Keep in mind the HTTP protocol may further wrap this data inside a chunked transfer encoding.
+به خاطر داشته باشید که پروتکل HTTP ممکن است این داده‌ها را در قالب **chunked transfer encoding** نیز بسته‌بندی کند.
 
-===== Downloading Data
+===== Downloading Data (دانلود داده)
 
 (((git commands, fetch-pack)))(((git commands, upload-pack)))
-When you download data, the `fetch-pack` and `upload-pack` processes are involved.
-The client initiates a `fetch-pack` process that connects to an `upload-pack` process on the remote side to negotiate what data will be transferred down.
+وقتی داده دریافت می‌کنید، فرآیندهای `fetch-pack` و `upload-pack` درگیر هستند.
+کلاینت فرآیند `fetch-pack` را اجرا می‌کند که به فرآیند `upload-pack` روی سمت ریموت متصل می‌شود تا مذاکره کند چه داده‌ای باید منتقل شود.
 
 ====== SSH
 
-If you're doing the fetch over SSH, `fetch-pack` runs something like this:
+اگر **fetch** را از طریق SSH انجام دهید، `fetch-pack` چیزی شبیه این اجرا می‌کند:
 
 [source,console]
 ----
 $ ssh -x git@server "git-upload-pack 'simplegit-progit.git'"
 ----
 
-After `fetch-pack` connects, `upload-pack` sends back something like this:
+پس از اتصال `fetch-pack`، فرآیند `upload-pack` چیزی شبیه این برمی‌گرداند:
 
 [source]
 ----
@@ -240,12 +238,12 @@ After `fetch-pack` connects, `upload-pack` sends back something like this:
 0000
 ----
 
-This is very similar to what `receive-pack` responds with, but the capabilities are different.
-In addition, it sends back what HEAD points to (`symref=HEAD:refs/heads/master`) so the client knows what to check out if this is a clone.
+این بسیار شبیه پاسخی است که `receive-pack` می‌دهد، اما قابلیت‌ها متفاوت هستند.
+علاوه بر این، مشخص می‌کند که **HEAD** به چه چیزی اشاره می‌کند (`symref=HEAD:refs/heads/master`) تا کلاینت بداند اگر این یک **clone** باشد، باید چه چیزی را **checkout** کند.
 
-At this point, the `fetch-pack` process looks at what objects it has and responds with the objects that it needs by sending "`want`" and then the SHA-1 it wants.
-It sends all the objects it already has with "`have`" and then the SHA-1.
-At the end of this list, it writes "`done`" to initiate the `upload-pack` process to begin sending the packfile of the data it needs:
+در این مرحله، فرآیند `fetch-pack` بررسی می‌کند چه **objects**‌ای دارد و با ارسال "`want`" همراه با مقدار **SHA-1**، اعلام می‌کند که چه چیزی می‌خواهد.
+سپس با ارسال "`have`" همراه با مقادیر **SHA-1**، مشخص می‌کند چه چیزی را دارد.
+در پایان این لیست، با نوشتن "`done`" فرآیند `upload-pack` را شروع می‌کند تا **packfile** داده‌های موردنیاز ارسال شود:
 
 [source]
 ----
@@ -255,10 +253,10 @@ At the end of this list, it writes "`done`" to initiate the `upload-pack` proces
 0000
 ----
 
-====== HTTP(S)
+====== HTTP(S) (پروتکل انتقال ابرمتن امن)
 
-The handshake for a fetch operation takes two HTTP requests.
-The first is a `GET` to the same endpoint used in the dumb protocol:
+**handshake** در عملیات **fetch** شامل دو درخواست HTTP است.
+اولی یک `GET` به همان **endpoint**ی است که در پروتکل **dumb** استفاده می‌شود:
 
 [source]
 ----
@@ -272,7 +270,7 @@ The first is a `GET` to the same endpoint used in the dumb protocol:
 0000
 ----
 
-This is very similar to invoking `git-upload-pack` over an SSH connection, but the second exchange is performed as a separate request:
+این بسیار شبیه اجرای `git-upload-pack` از طریق SSH است، اما تبادل دوم به‌عنوان یک درخواست جداگانه انجام می‌شود:
 
 [source]
 ----
@@ -282,11 +280,11 @@ This is very similar to invoking `git-upload-pack` over an SSH connection, but t
 0000
 ----
 
-Again, this is the same format as above.
-The response to this request indicates success or failure, and includes the packfile.
+باز هم فرمت همان قبلی است.
+پاسخ این درخواست موفقیت یا شکست را مشخص می‌کند و شامل **packfile** است.
 
-==== Protocols Summary
+==== Protocols Summary (خلاصه پروتکل‌ها)
 
-This section contains a very basic overview of the transfer protocols.
-The protocol includes many other features, such as `multi_ack` or `side-band` capabilities, but covering them is outside the scope of this book.
-We've tried to give you a sense of the general back-and-forth between client and server; if you need more knowledge than this, you'll probably want to take a look at the Git source code.
+این بخش یک مرور بسیار ابتدایی از پروتکل‌های انتقال داده بود.
+پروتکل ویژگی‌های بسیار بیشتری دارد، مثل قابلیت‌های `multi_ack` یا `side-band`، اما توضیح آن‌ها خارج از محدوده این کتاب است.
+ما سعی کردیم حسی کلی از تعاملات بین کلاینت و سرور به شما بدهیم؛ اگر به دانشی بیشتر از این نیاز دارید، احتمالاً باید به **Git source code** مراجعه کنید.


### PR DESCRIPTION
This pull request contains a full Persian (Farsi) translation of the "Environment Variables" section in the `book/10-git-internals/sections/environment.asc` file, making the content accessible to Persian-speaking readers. The translation covers all subsections, including global behavior, repository locations, pathspecs, committing, networking, diffing and merging, debugging, and miscellaneous environment variables. Additionally, minor updates were made to the `.idea/workspace.xml` file to reflect recent workspace activity and branch usage.

**Translation of Environment Variables Section:**

- The entire "Environment Variables" section was translated into Persian, including all explanations, variable descriptions, and code comments. This makes the technical documentation more accessible to Persian readers and ensures consistency with the rest of the translated book. [[1]](diffhunk://#diff-29ce6775ac8ce410c39536935f9f8e83eac06c9a1028e41b681395ab30eeb0bfL1-R129) [[2]](diffhunk://#diff-29ce6775ac8ce410c39536935f9f8e83eac06c9a1028e41b681395ab30eeb0bfL141-R143) [[3]](diffhunk://#diff-29ce6775ac8ce410c39536935f9f8e83eac06c9a1028e41b681395ab30eeb0bfL158-R159) [[4]](diffhunk://#diff-29ce6775ac8ce410c39536935f9f8e83eac06c9a1028e41b681395ab30eeb0bfL171-R173) [[5]](diffhunk://#diff-29ce6775ac8ce410c39536935f9f8e83eac06c9a1028e41b681395ab30eeb0bfL194-R195) [[6]](diffhunk://#diff-29ce6775ac8ce410c39536935f9f8e83eac06c9a1028e41b681395ab30eeb0bfL208-R232)

**Workspace Configuration Updates:**

- Updated `.idea/workspace.xml` to reflect the recent switch to the `book/translation/10-git-internals` branch, updated recent branches, and logged additional work items. These changes help maintain accurate project metadata and streamline development workflow. [[1]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cR86-R89) [[2]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL133-R135) [[3]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cR186-R188)
- Cleaned up the change list in `.idea/workspace.xml` by removing a reference to a previously tracked file.