### PR TITLE
translate(B-embedding-git): translated command-line to persian

### DIFF
--- a/book/B-embedding-git/sections/command-line.asc
+++ b/book/B-embedding-git/sections/command-line.asc
@@ -1,16 +1,16 @@
-=== Command-line Git
+=== Command-line Git (خط فرمان گیت)
 
-One option is to spawn a shell process and use the Git command-line tool to do the work.
-This has the benefit of being canonical, and all of Git's features are supported.
-This also happens to be fairly easy, as most runtime environments have a relatively simple facility for invoking a process with command-line arguments.
-However, this approach does have some downsides.
+یک گزینه این است که یک فرایند شل ایجاد کرده و از ابزار خط فرمان Git برای انجام کارها استفاده کنید.
+این روش مزیت canonical بودن را دارد و تمام ویژگی‌های Git پشتیبانی می‌شوند.
+همچنین نسبتاً ساده است، زیرا اکثر محیط‌های اجرایی امکانات نسبتاً ساده‌ای برای فراخوانی یک فرایند با آرگومان‌های خط فرمان دارند.
+با این حال، این رویکرد معایبی نیز دارد.
 
-One is that all the output is in plain text.
-This means that you'll have to parse Git's occasionally-changing output format to read progress and result information, which can be inefficient and error-prone.
+یکی از معایب این است که تمام خروجی به صورت متن ساده (plain text) است.
+این یعنی شما باید فرمت خروجی Git که گاهی تغییر می‌کند را تحلیل (parse) کنید تا اطلاعات پیشرفت و نتیجه را بخوانید، که می‌تواند ناکارآمد و مستعد خطا باشد.
 
-Another is the lack of error recovery.
-If a repository is corrupted somehow, or the user has a malformed configuration value, Git will simply refuse to perform many operations.
+دیگر کمبود این است که قابلیت بازیابی از خطا محدود است.
+اگر یک مخزن به‌نوعی خراب شود یا کاربر مقداری نادرست در تنظیمات داشته باشد، Git بسیاری از عملیات را به سادگی انجام نخواهد داد.
 
-Yet another is process management.
-Git requires you to maintain a shell environment on a separate process, which can add unwanted complexity.
-Trying to coordinate many of these processes (especially when potentially accessing the same repository from several processes) can be quite a challenge.
+و دیگری مدیریت فرایندها است.
+Git نیاز دارد که یک محیط شل را در یک فرایند جداگانه نگه دارید، که می‌تواند پیچیدگی غیرضروری ایجاد کند.
+سعی در هماهنگ‌سازی چندین فرایند از این نوع (به‌ویژه زمانی که چند فرایند ممکن است به همان مخزن دسترسی داشته باشند) می‌تواند چالش‌برانگیز باشد.

--- a/book/B-embedding-git/sections/dulwich.asc
+++ b/book/B-embedding-git/sections/dulwich.asc
@@ -1,14 +1,14 @@
-=== Dulwich
+=== Dulwich (کتابخانه گیت پایتون)
 
 (((Dulwich)))(((Python)))
-There is also a pure-Python Git implementation - Dulwich.
-The project is hosted under https://www.dulwich.io/[^].
-It aims to provide an interface to Git repositories (both local and remote) that doesn't call out to Git directly but instead uses pure Python.
-It has an optional C extensions though, that significantly improve the performance.
+یک پیاده‌سازی کامل Git به زبان پایتون نیز وجود دارد — Dulwich.
+این پروژه در آدرس https://www.dulwich.io/[^] میزبانی می‌شود.
+هدف آن ارائه یک رابط (interface) برای مخازن Git (هم محلی و هم راه‌دور) است که مستقیماً Git را فراخوانی نکند و به‌جای آن از پایتون خالص استفاده کند.
+با این حال، Dulwich دارای افزونه‌های C اختیاری است که عملکرد را به‌طور قابل‌توجهی بهبود می‌بخشند.
 
-Dulwich follows Git design and separate two basic levels of API: plumbing and porcelain.
+Dulwich از طراحی Git پیروی می‌کند و دو سطح پایه API را از هم جدا می‌کند: **plumbing** و **porcelain**.
 
-Here is an example of using the lower level API to access the commit message of the last commit:
+در اینجا مثالی از استفاده از API سطح پایین برای دسترسی به پیام آخرین commit آمده است:
 
 [source, python]
 ----
@@ -25,7 +25,7 @@ c.message
 # 'Add note about encoding.\n'
 ----
 
-To print a commit log using high-level porcelain API, one can use:
+برای چاپ لاگ commit با استفاده از API سطح بالای **porcelain**، می‌توان از روش زیر استفاده کرد:
 
 [source, python]
 ----
@@ -37,6 +37,6 @@ porcelain.log('.', max_entries=1)
 #Date:   Sat Apr 29 2017 23:57:34 +0000
 ----
 
-==== Further Reading
+==== Further Reading (مطالعه بیشتر)
 
-The API documentation, tutorial, and many examples of how to do specific tasks with Dulwich are available on the official website https://www.dulwich.io[^].
+مستندات API، آموزش‌ها و بسیاری از مثال‌های انجام کارهای مشخص با Dulwich در وبسایت رسمی آن در دسترس است: https://www.dulwich.io[^].

--- a/book/B-embedding-git/sections/go-git.asc
+++ b/book/B-embedding-git/sections/go-git.asc
@@ -1,13 +1,13 @@
-=== go-git
+=== go-git (کتابخانه گیت برای زبان Go)
 
 (((go-git)))(((Go)))
-In case you want to integrate Git into a service written in Golang, there also is a pure Go library implementation.
-This implementation does not have any native dependencies and thus is not prone to manual memory management errors.
-It is also transparent for the standard Golang performance analysis tooling like CPU, Memory profilers, race detector, etc.
+اگر می‌خواهید Git را در یک سرویس نوشته‌شده با Golang ادغام کنید، یک پیاده‌سازی کامل به زبان Go نیز وجود دارد.
+این پیاده‌سازی هیچ وابستگی بومی (native) ندارد و بنابراین در معرض خطاهای مدیریت حافظه دستی نیست.
+همچنین برای ابزارهای استاندارد تحلیل عملکرد Golang مانند پروفایلر CPU، پروفایلر حافظه، و race detector شفاف است.
 
-go-git is focused on extensibility, compatibility and supports most of the plumbing APIs, which is documented at https://github.com/go-git/go-git/blob/master/COMPATIBILITY.md[^].
+go-git بر **قابلیت توسعه (extensibility)** و **سازگاری** تمرکز دارد و از بیشتر APIهای سطح پایین (**plumbing**) پشتیبانی می‌کند، که مستندات آن در https://github.com/go-git/go-git/blob/master/COMPATIBILITY.md[^] موجود است.
 
-Here is a basic example of using Go APIs:
+در اینجا یک مثال ساده از استفاده از APIهای Go آمده است:
 
 [source, go]
 ----
@@ -19,7 +19,7 @@ r, err := git.PlainClone("/tmp/foo", false, &git.CloneOptions{
 })
 ----
 
-As soon as you have a `Repository` instance, you can access information and perform mutations on it:
+به محض اینکه یک نمونه `Repository` داشته باشید، می‌توانید اطلاعات را دسترسی پیدا کرده و تغییرات موردنظر را روی آن اعمال کنید:
 
 [source, go]
 ----
@@ -38,10 +38,10 @@ for _, c := range history {
 }
 ----
 
-==== Advanced Functionality
+==== Advanced Functionality (قابلیت‌های پیشرفته)
 
-go-git has few notable advanced features, one of which is a pluggable storage system, which is similar to Libgit2 backends.
-The default implementation is in-memory storage, which is very fast.
+go-git دارای چند ویژگی پیشرفته قابل توجه است، یکی از آنها **سیستم ذخیره‌سازی قابل افزونه (pluggable storage)** است، مشابه backendهای Libgit2.
+پیاده‌سازی پیش‌فرض، **ذخیره‌سازی در حافظه (in-memory)** است که بسیار سریع است.
 
 [source, go]
 ----
@@ -50,13 +50,13 @@ r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
 })
 ----
 
-Pluggable storage provides many interesting options.
-For instance, https://github.com/go-git/go-git/tree/master/_examples/storage[^] allows you to store references, objects, and configuration in an Aerospike database.
+سیستم ذخیره‌سازی قابل افزونه گزینه‌های جالبی ارائه می‌دهد.
+برای مثال، https://github.com/go-git/go-git/tree/master/_examples/storage[^] امکان ذخیره رفرنس‌ها، اشیاء و تنظیمات در یک پایگاه داده Aerospike را فراهم می‌کند.
 
-Another feature is a flexible filesystem abstraction.
-Using https://pkg.go.dev/github.com/go-git/go-billy/v5?tab=doc#Filesystem[^] it is easy to store all the files in different way i.e by packing all of them to a single archive on disk or by keeping them all in-memory.
+ویژگی دیگر، **انتزاع انعطاف‌پذیر سیستم فایل (flexible filesystem abstraction)** است.
+با استفاده از https://pkg.go.dev/github.com/go-git/go-billy/v5?tab=doc#Filesystem[^] می‌توان همه فایل‌ها را به روش‌های مختلف ذخیره کرد، مثلاً با فشرده‌سازی همه در یک آرشیو روی دیسک یا نگهداری همه در حافظه.
 
-Another advanced use-case includes a fine-tunable HTTP client, such as the one found at https://github.com/go-git/go-git/blob/master/_examples/custom_http/main.go[^].
+یک کاربرد پیشرفته دیگر، **کلاینت HTTP قابل تنظیم دقیق** است، مانند نمونه موجود در https://github.com/go-git/go-git/blob/master/_examples/custom_http/main.go[^].
 
 [source, go]
 ----
@@ -77,7 +77,7 @@ client.InstallProtocol("https", githttp.NewClient(customClient))
 r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{URL: url})
 ----
 
-==== Further Reading
+==== Further Reading (مطالعه بیشتر)
 
-A full treatment of go-git's capabilities is outside the scope of this book.
-If you want more information on go-git, there's API documentation at https://pkg.go.dev/github.com/go-git/go-git/v5[^], and a set of usage examples at https://github.com/go-git/go-git/tree/master/_examples[^].
+بررسی کامل قابلیت‌های go-git خارج از محدوده این کتاب است.
+برای اطلاعات بیشتر در مورد go-git، مستندات API در https://pkg.go.dev/github.com/go-git/go-git/v5[^] و مجموعه‌ای از مثال‌های کاربردی در https://github.com/go-git/go-git/tree/master/_examples[^] در دسترس هستند.

--- a/book/B-embedding-git/sections/jgit.asc
+++ b/book/B-embedding-git/sections/jgit.asc
@@ -1,14 +1,14 @@
-=== JGit
+=== JGit (کتابخانه گیت برای زبان Java)
 
 (((jgit)))(((Java)))
-If you want to use Git from within a Java program, there is a fully featured Git library called JGit.
-JGit is a relatively full-featured implementation of Git written natively in Java, and is widely used in the Java community.
-The JGit project is under the Eclipse umbrella, and its home can be found at https://www.eclipse.org/jgit/[^].
+اگر می‌خواهید Git را در یک برنامه Java استفاده کنید، یک کتابخانه کامل به نام **JGit** وجود دارد.
+JGit یک پیاده‌سازی نسبتاً کامل Git است که به‌صورت native در Java نوشته شده و در جامعه Java به‌طور گسترده استفاده می‌شود.
+پروژه JGit تحت مجموعه Eclipse قرار دارد و صفحه اصلی آن در https://www.eclipse.org/jgit/[^] قابل دسترسی است.
 
-==== Getting Set Up
+==== Getting Set Up (راه‌اندازی)
 
-There are a number of ways to connect your project with JGit and start writing code against it.
-Probably the easiest is to use Maven – the integration is accomplished by adding the following snippet to the `<dependencies>` tag in your `pom.xml` file:
+راه‌های مختلفی برای اتصال پروژه شما به JGit و شروع برنامه‌نویسی وجود دارد.
+احتمالاً ساده‌ترین روش استفاده از **Maven** است – با اضافه کردن قطعه زیر به تگ `<dependencies>` در فایل `pom.xml` خود:
 
 [source,xml]
 ----
@@ -19,11 +19,11 @@ Probably the easiest is to use Maven – the integration is accomplished by addi
 </dependency>
 ----
 
-The `version` will most likely have advanced by the time you read this; check https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit[^] for updated repository information.
-Once this step is done, Maven will automatically acquire and use the JGit libraries that you'll need.
+نسخه (`version`) احتمالاً تا زمان مطالعه شما به‌روز شده است؛ برای اطلاعات جدیدتر، https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit[^] را بررسی کنید.
+پس از انجام این مرحله، Maven به‌طور خودکار کتابخانه‌های JGit مورد نیاز شما را دریافت و استفاده خواهد کرد.
 
-If you would rather manage the binary dependencies yourself, pre-built JGit binaries are available from https://www.eclipse.org/jgit/download[^].
-You can build them into your project by running a command like this:
+اگر ترجیح می‌دهید وابستگی‌های باینری را خودتان مدیریت کنید، باینری‌های پیش‌ساخته JGit از https://www.eclipse.org/jgit/download[^] در دسترس هستند.
+می‌توانید آن‌ها را با اجرای دستوری مشابه زیر در پروژه خود وارد کنید:
 
 [source,console]
 ----
@@ -31,13 +31,15 @@ javac -cp .:org.eclipse.jgit-3.5.0.201409260305-r.jar App.java
 java -cp .:org.eclipse.jgit-3.5.0.201409260305-r.jar App
 ----
 
-==== Plumbing
+==== Plumbing (عملیات سطح پایین)
 
-JGit has two basic levels of API: plumbing and porcelain.
-The terminology for these comes from Git itself, and JGit is divided into roughly the same kinds of areas: porcelain APIs are a friendly front-end for common user-level actions (the sorts of things a normal user would use the Git command-line tool for), while the plumbing APIs are for interacting with low-level repository objects directly.
+JGit دو سطح پایه API دارد: **plumbing** و **porcelain**.
+این اصطلاحات از Git گرفته شده و JGit نیز تقریباً به همان بخش‌ها تقسیم می‌شود:
+- APIهای **porcelain** یک رابط کاربرپسند برای عملیات معمولی سطح کاربر هستند (همان کارهایی که کاربر معمولی با خط فرمان Git انجام می‌دهد).
+- APIهای **plumbing** برای تعامل مستقیم با اشیاء سطح پایین مخزن هستند.
 
-The starting point for most JGit sessions is the `Repository` class, and the first thing you'll want to do is create an instance of it.
-For a filesystem-based repository (yes, JGit allows for other storage models), this is accomplished using `FileRepositoryBuilder`:
+نقطه شروع اکثر جلسات JGit، کلاس `Repository` است و اولین کاری که باید انجام دهید ایجاد یک نمونه از آن است.
+برای مخزنی مبتنی بر سیستم فایل (JGit اجازه استفاده از مدل‌های ذخیره‌سازی دیگر را نیز می‌دهد)، این کار با استفاده از `FileRepositoryBuilder` انجام می‌شود:
 
 [source,java]
 ----
@@ -52,11 +54,11 @@ Repository existingRepo = new FileRepositoryBuilder()
     .build();
 ----
 
-The builder has a fluent API for providing all the things it needs to find a Git repository, whether or not your program knows exactly where it's located.
-It can use environment variables (`.readEnvironment()`), start from a place in the working directory and search (`.setWorkTree(…).findGitDir()`), or just open a known `.git` directory as above.
+Builder یک API روان برای ارائه همه چیزهایی که برای پیدا کردن یک مخزن Git نیاز دارد، ارائه می‌دهد، چه برنامه شما مکان دقیق آن را بداند و چه ندانند.
+می‌تواند از متغیرهای محیطی استفاده کند (`.readEnvironment()`)، از جایی در دایرکتوری کاری شروع کرده و جستجو کند (`.setWorkTree(…).findGitDir()`)، یا به سادگی یک دایرکتوری `.git` شناخته‌شده را باز کند.
 
-Once you have a `Repository` instance, you can do all sorts of things with it.
-Here's a quick sampling:
+به محض اینکه یک نمونه `Repository` داشته باشید، می‌توانید کارهای متنوعی با آن انجام دهید.
+در ادامه چند نمونه سریع آورده شده است:
 
 [source,java]
 ----
@@ -88,37 +90,34 @@ Config cfg = repo.getConfig();
 String name = cfg.getString("user", null, "name");
 ----
 
-There's quite a bit going on here, so let's go through it one section at a time.
+در اینجا نکات مهمی وجود دارد:
 
-The first line gets a pointer to the `master` reference.
-JGit automatically grabs the _actual_ `master` ref, which lives at `refs/heads/master`, and returns an object that lets you fetch information about the reference.
-You can get the name (`.getName()`), and either the target object of a direct reference (`.getObjectId()`) or the reference pointed to by a symbolic ref (`.getTarget()`).
-Ref objects are also used to represent tag refs and objects, so you can ask if the tag is "`peeled,`" meaning that it points to the final target of a (potentially long) string of tag objects.
+خط اول یک اشاره‌گر به مرجع «master» می‌گیرد.
+JGit به‌طور خودکار مرجع واقعی master را که در refs/heads/master قرار دارد می‌گیرد و شیئی برمی‌گرداند که اجازه می‌دهد اطلاعاتی دربارهٔ آن مرجع بازیابی کنید.
+می‌توانید نام آن را (.getName()) دریافت کنید، و یا شیء هدف یک مرجع مستقیم (.getObjectId()) یا مرجعی که یک مرجع نمادین به آن اشاره می‌کند (.getTarget()) را بدست آورید.
+اشیای Ref همچنین برای نمایش ارجاعات برچسب‌ها و اشیا استفاده می‌شوند، بنابراین می‌توانید بپرسید که آیا برچسب «peeled» شده است، بدین معنی که به هدف نهایی یک زنجیره (احتمالاً طولانی) از اشیای برچسب اشاره می‌کند.
 
-The second line gets the target of the `master` reference, which is returned as an ObjectId instance.
-ObjectId represents the SHA-1 hash of an object, which might or might not exist in Git's object database.
-The third line is similar, but shows how JGit handles the rev-parse syntax (for more on this, see <<ch07-git-tools#_branch_references>>); you can pass any object specifier that Git understands, and JGit will return either a valid ObjectId for that object, or `null`.
+خط دوم هدف مرجع master را می‌گیرد که به‌صورت یک نمونهٔ ObjectId برگردانده می‌شود.
+ObjectId نمایانگر هش SHA-1 یک شیء است که ممکن است در پایگاه‌داده اشیأ گیت وجود داشته باشد یا نه.
+خط سوم مشابه است، اما نشان می‌دهد JGit چگونه نحو rev-parse را مدیریت می‌کند (برای اطلاعات بیشتر رجوع کنید به <<ch07-git-tools#_branch_references>>); می‌توانید هر مشخص‌کنندهٔ شیئی را که گیت می‌فهمد ارسال کنید، و JGit یا یک ObjectId معتبر برای آن شیء برمی‌گرداند، یا null.
 
-The next two lines show how to load the raw contents of an object.
-In this example, we call `ObjectLoader.copyTo()` to stream the contents of the object directly to stdout, but ObjectLoader also has methods to read the type and size of an object, as well as return it as a byte array.
-For large objects (where `.isLarge()` returns `true`), you can call `.openStream()` to get an InputStream-like object that can read the raw object data without pulling it all into memory at once.
+دو خط بعدی نشان می‌دهند چگونه محتوای خام یک شیء را بارگذاری کنید.
+در این مثال، ما از ObjectLoader.copyTo() برای پخش محتویات شیء مستقیماً به خروجی استاندارد استفاده می‌کنیم، اما ObjectLoader همچنین متدهایی برای خواندن نوع و اندازهٔ یک شیء و همچنین بازگرداندنش به‌صورت یک آرایه بایت دارد.
+برای اشیای بزرگ‌تر (جایی که .isLarge() مقدار true برمی‌گرداند)، می‌توانید از .openStream() برای گرفتن یک شیء شبیه InputStream استفاده کنید که قادر است دادهٔ خام شیء را بدون بارگذاری کامل آن در حافظه بخواند.
 
-The next few lines show what it takes to create a new branch.
-We create a RefUpdate instance, configure some parameters, and call `.update()` to trigger the change.
-Directly following this is the code to delete that same branch.
-Note that `.setForceUpdate(true)` is required for this to work; otherwise the `.delete()` call will return `REJECTED`, and nothing will happen.
+چند خط بعدی نشان می‌دهد چه کارهایی لازم است تا یک شاخهٔ جدید ایجاد شود.
+ما یک نمونهٔ RefUpdate می‌سازیم، چند پارامتر را پیکربندی می‌کنیم و با فراخوانی .update() تغییر را اجرا می‌کنیم.
+بلافاصله پس از آن کدی هست برای حذف همان شاخه.
+توجه داشته باشید که .setForceUpdate(true) برای این کار لازم است؛ در غیر این صورت فراخوانی .delete() مقدار REJECTED را بازمی‌گرداند و هیچ کاری انجام نخواهد شد.
 
-The last example shows how to fetch the `user.name` value from the Git configuration files.
-This Config instance uses the repository we opened earlier for local configuration, but will automatically detect the global and system configuration files and read values from them as well.
+ این تنها نمونهٔ کوچکی از کل APIِ سطح پایین (plumbing) است؛ روش‌ها و کلاس‌های بسیار بیشتری موجودند.
+همچنین در اینجا نحوهٔ رسیدگی JGit به خطاها نشان داده نشده است که از طریق استفاده از استثناها (exceptions) انجام می‌شود.
+API‌های JGit گاهی استثناهای استاندارد جاوا مانند IOException را پرتاب می‌کنند، ولی مجموعه‌ای از انواع استثناهای خاص JGit نیز وجود دارد (مثل NoRemoteRepositoryException، CorruptObjectException و NoMergeBaseException).
 
-This is only a small sampling of the full plumbing API; there are many more methods and classes available.
-Also not shown here is the way JGit handles errors, which is through the use of exceptions.
-JGit APIs sometimes throw standard Java exceptions (such as `IOException`), but there are a host of JGit-specific exception types that are provided as well (such as `NoRemoteRepositoryException`, `CorruptObjectException`, and `NoMergeBaseException`).
+==== Porcelain (رابط سطح بالا)
 
-==== Porcelain
-
-The plumbing APIs are rather complete, but it can be cumbersome to string them together to achieve common goals, like adding a file to the index, or making a new commit.
-JGit provides a higher-level set of APIs to help out with this, and the entry point to these APIs is the `Git` class:
+APIهای سطح پایین نسبتاً کامل هستند، اما کنار هم قرار دادن آن‌ها برای رسیدن به اهداف متداول—مثل افزودن یک فایل به ایندکس یا ساختن یک commit جدید—می‌تواند دست‌وپاگیر باشد.
+JGit مجموعه‌ای از APIهای سطح بالاتر ارائه می‌دهد تا در این مسیر کمک کند و نقطهٔ ورود به این APIها کلاس Git است:
 
 [source,java]
 ----
@@ -127,8 +126,8 @@ Repository repo;
 Git git = new Git(repo);
 ----
 
-The Git class has a nice set of high-level _builder_-style methods that can be used to construct some pretty complex behavior.
-Let's take a look at an example -- doing something like `git ls-remote`:
+کلاس Git دارای مجموعه‌ای مناسب از متدهای سطح بالا به سبک «سازنده» (builder) است که می‌توان از آن‌ها برای ساخت رفتارهای نسبتاً پیچیده استفاده کرد.
+بیایید به یک مثال نگاه کنیم — انجام عملی شبیه git ls-remote:
 
 [source,java]
 ----
@@ -144,17 +143,17 @@ for (Ref ref : remoteRefs) {
 }
 ----
 
-This is a common pattern with the Git class; the methods return a command object that lets you chain method calls to set parameters, which are executed when you call `.call()`.
-In this case, we're asking the `origin` remote for tags, but not heads.
-Also notice the use of a `CredentialsProvider` object for authentication.
+این یک الگوی رایج در کلاس Git است؛ متدها یک شیء فرمان (command object) برمی‌گردانند که به شما امکان زنجیره‌ای کردن فراخوانی متدها برای تنظیم پارامترها را می‌دهد و وقتی که متد .call() را فراخوانی می‌کنید اجرا می‌شوند.
+در این مثال، ما از remote به نام origin درخواست تگ‌ها را کرده‌ایم، اما نه heads.
+همچنین به استفاده از شیء CredentialsProvider برای احراز هویت توجه کنید.
 
-Many other commands are available through the Git class, including but not limited to `add`, `blame`, `commit`, `clean`, `push`, `rebase`, `revert`, and `reset`.
+بسیاری از فرمان‌های دیگر نیز از طریق کلاس Git در دسترس‌اند، از جمله اما نه محدود به add، blame، commit، clean، push، rebase، revert و reset.
 
-==== Further Reading
+==== Further Reading (مطالعه بیشتر)
 
-This is only a small sampling of JGit's full capabilities.
-If you're interested and want to learn more, here's where to look for information and inspiration:
+این تنها نمونهٔ کوچکی از توانمندی‌های کامل JGit است.
+اگر علاقه‌مندید و می‌خواهید بیشتر بیاموزید، منابع و راهنمایی‌های بعدی را ببینید:
 
-* The official JGit API documentation can be found at https://www.eclipse.org/jgit/documentation[^].
-  These are standard Javadoc, so your favorite JVM IDE will be able to install them locally, as well.
-* The JGit Cookbook at https://github.com/centic9/jgit-cookbook[^] has many examples of how to do specific tasks with JGit.
+* مستندات رسمی APIِ JGit را می‌توانید در https://www.eclipse.org/jgit/documentation بیابید.
+  این‌ها Javadoc استاندارد هستند، بنابراین IDE محبوب شما برای JVM هم می‌تواند آن‌ها را به‌صورت محلی نصب کند.
+* کتاب آشپزخانهٔ JGit (JGit Cookbook) در https://github.com/centic9/jgit-cookbook نمونه‌های متعددی از انجام کارهای مشخص با JGit را شامل می‌شود.

--- a/book/B-embedding-git/sections/libgit2.asc
+++ b/book/B-embedding-git/sections/libgit2.asc
@@ -1,12 +1,12 @@
-=== Libgit2
+=== Libgit2 (کتابخانهٔ گیت به زبان C)
 
 (((libgit2)))((("C")))
-Another option at your disposal is to use Libgit2.
-Libgit2 is a dependency-free implementation of Git, with a focus on having a nice API for use within other programs.
-You can find it at https://libgit2.org[^].
+گزینهٔ دیگر در اختیار شما استفاده از Libgit2 است.
+Libgit2 پیاده‌سازی بدون وابستگی از گیت است که تمرکز آن بر ارائهٔ یک API خوب برای استفاده در برنامه‌های دیگر است.
+می‌توانید آن را در https://libgit2.org بیابید.
 
-First, let's take a look at what the C API looks like.
-Here's a whirlwind tour:
+ابتدا نگاهی به شکل API در زبان C می‌اندازیم.
+در اینجا یک مرور سریع آمده است:
 
 [source,c]
 ----
@@ -30,31 +30,31 @@ git_commit_free(commit);
 git_repository_free(repo);
 ----
 
-The first couple of lines open a Git repository.
-The `git_repository` type represents a handle to a repository with a cache in memory.
-This is the simplest method, for when you know the exact path to a repository's working directory or `.git` folder.
-There's also the `git_repository_open_ext` which includes options for searching, `git_clone` and friends for making a local clone of a remote repository, and `git_repository_init` for creating an entirely new repository.
+دو خط اول یک مخزن گیت را باز می‌کنند.
+نوع git_repository نمایانگر یک دسته‌گانه (handle) به مخزنی است که یک حافظهٔ نهان در رم دارد.
+این ساده‌ترین روش است، برای زمانی که مسیر دقیق پوشهٔ کاری مخزن یا فولدر .git را می‌دانید.
+همچنین git_repository_open_ext وجود دارد که شامل گزینه‌هایی برای جستجوست، و توابعی مانند git_clone برای ساخت یک نسخهٔ محلی از یک مخزن راه‌دور، و git_repository_init برای ایجاد یک مخزن کاملاً جدید.
 
-The second chunk of code uses rev-parse syntax (see <<ch07-git-tools#_branch_references>> for more on this) to get the commit that HEAD eventually points to.
-The type returned is a `git_object` pointer, which represents something that exists in the Git object database for a repository.
-`git_object` is actually a "`parent`" type for several different kinds of objects; the memory layout for each of the "`child`" types is the same as for `git_object`, so you can safely cast to the right one.
-In this case, `git_object_type(commit)` would return `GIT_OBJ_COMMIT`, so it's safe to cast to a `git_commit` pointer.
+بخش دوم کد از نحو rev-parse استفاده می‌کند (برای اطلاعات بیشتر رجوع کنید به <<ch07-git-tools#_branch_references>>) تا کمیتی که HEAD در نهایت به آن اشاره می‌کند را بگیرد.
+نوع بازگشتی اشاره‌گری به git_object است، که چیزی را نشان می‌دهد که در پایگاه دادهٔ شئ‌های گیت یک مخزن وجود دارد.
+git_object در واقع نوع «والد» برای چندین نوع شئ مختلف است؛ چیدمان حافظه برای هر یک از انواع «فرزند» همانند git_object است، لذا می‌توان با اطمینان آن را به نوع مناسب تبدیل کرد.
+در این مورد git_object_type(commit) مقدار GIT_OBJ_COMMIT را بازمی‌گرداند، بنابراین امن است که آن را به اشاره‌گر git_commit تبدیل کنیم.
 
-The next chunk shows how to access the commit's properties.
-The last line here uses a `git_oid` type; this is Libgit2's representation for a SHA-1 hash.
+قسمت بعدی نشان می‌دهد چگونه به ویژگی‌های کمیت دسترسی داشته باشیم.
+خط آخر از نوع git_oid استفاده می‌کند؛ این نمایش Libgit2 برای هش SHA-1 است.
 
-From this sample, a couple of patterns have started to emerge:
+از این نمونه، چند الگو شروع به آشکار شدن کرده‌اند:
 
-* If you declare a pointer and pass a reference to it into a Libgit2 call, that call will probably return an integer error code.
-  A `0` value indicates success; anything less is an error.
-* If Libgit2 populates a pointer for you, you're responsible for freeing it.
-* If Libgit2 returns a `const` pointer from a call, you don't have to free it, but it will become invalid when the object it belongs to is freed.
-* Writing C is a bit painful.
+* اگر اشاره‌گری را اعلام کنید و مرجعی به آن را به یک فراخوانی Libgit2 بدهید، آن فراخوانی احتمالاً یک کد خطای عددی برمی‌گرداند.
+  مقدار `0` نشان‌دهندهٔ موفقیت است؛ هر مقدار کمتر از آن خطا محسوب می‌شود.
+* اگر Libgit2 برایتان یک اشاره‌گر را مقداردهی کند، مسئول آزادسازی آن بر عهدهٔ شماست.
+* اگر Libgit2 از یک فراخوانی اشاره‌گر `const` برگرداند، نیازی به آزادسازی آن نیست، اما آن اشاره‌گر زمانی که شی‌ای که متعلق به آن است آزاد شود نامعتبر خواهد شد.
+* نوشتن به زبان C کمی دردسر دارد.
 
 (((Ruby)))
-That last one means it isn't very probable that you'll be writing C when using Libgit2.
-Fortunately, there are a number of language-specific bindings available that make it fairly easy to work with Git repositories from your specific language and environment.
-Let's take a look at the above example written using the Ruby bindings for Libgit2, which are named Rugged, and can be found at https://github.com/libgit2/rugged[^].
+مورد آخر یعنی احتمال اینکه هنگام استفاده از Libgit2 خودتان بخواهید C بنویسید خیلی کم است.
+خوشبختانه، تعدادی binding مخصوص زبان‌های مختلف موجود است که کار با مخازن Git را از زبان و محیط شما نسبتاً ساده می‌کنند.
+بیایید همان مثال بالا را که با bindingهای Ruby برای Libgit2 نوشته شده — که Rugged نام دارد و در https://github.com/libgit2/rugged[^] یافت می‌شود — بررسی کنیم.
 
 [source,ruby]
 ----
@@ -65,10 +65,10 @@ puts "#{commit.author[:name]} <#{commit.author[:email]}>"
 tree = commit.tree
 ----
 
-As you can see, the code is much less cluttered.
-Firstly, Rugged uses exceptions; it can raise things like `ConfigError` or `ObjectError` to signal error conditions.
-Secondly, there's no explicit freeing of resources, since Ruby is garbage-collected.
-Let's take a look at a slightly more complicated example: crafting a commit from scratch
+همان‌طور که می‌بینید، کد خیلی کم‌پلوتر (تمیزتر) است.
+اولاً، Rugged از استثناها استفاده می‌کند؛ مثلاً می‌تواند خطاهایی مانند `ConfigError` یا `ObjectError` را برای نشان‌دادن شرایط خطا پرتاب کند.
+ثانیاً، نیازی به آزادسازی صریح منابع نیست، چون Ruby دارای جمع‌آوری زباله است.
+بیایید نگاهی به مثال کمی پیچیده‌تر بیندازیم: ساختن یک commit از صفر
 
 [source,ruby]
 ----
@@ -95,28 +95,28 @@ commit_id = Rugged::Commit.create(repo,
 commit = repo.lookup(commit_id) # <8>
 ----
 
-<1> Create a new blob, which contains the contents of a new file.
-<2> Populate the index with the head commit's tree, and add the new file at the path `newfile.txt`.
-<3> This creates a new tree in the ODB, and uses it for the new commit.
-<4> We use the same signature for both the author and committer fields.
-<5> The commit message.
-<6> When creating a commit, you have to specify the new commit's parents.
-    This uses the tip of HEAD for the single parent.
-<7> Rugged (and Libgit2) can optionally update a reference when making a commit.
-<8> The return value is the SHA-1 hash of a new commit object, which you can then use to get a `Commit` object.
+<1> یک blob جدید ایجاد کنید که شامل محتوای یک فایل جدید است.
+<2> ایندکس را با درخت commitِ HEAD مقداردهی کنید و فایل جدید را در مسیر `newfile.txt` اضافه کنید.
+<3> این یک درخت جدید در ODB ایجاد می‌کند و آن را برای commit جدید استفاده می‌کند.
+<4> برای فیلدهای author و committer از یک امضای یکسان استفاده می‌کنیم.
+<5> پیام commit.
+<6> هنگام ایجاد یک commit باید والد(های) commit جدید را مشخص کنید.
+    این مثال از نوک HEAD به عنوان والدِ یگانه استفاده می‌کند.
+<7> Rugged (و Libgit2) می‌توانند به‌صورت اختیاری هنگام ساختن commit یک reference را به‌روزرسانی کنند.
+<8> مقدار بازگشتی، هش SHA-1 یک شیء commit جدید است که می‌توانید از آن برای گرفتن یک شیٔ `Commit` استفاده کنید.
 
-The Ruby code is nice and clean, but since Libgit2 is doing the heavy lifting, this code will run pretty fast, too.
-If you're not a rubyist, we touch on some other bindings in <<_libgit2_bindings>>.
+ کد روبی تمیز و خوب است، و چون Libgit2 کار سنگین را انجام می‌دهد، این کد هم نسبتاً سریع اجرا خواهد شد.
+اگر برنامه‌نویس روبی نیستید، به سایر بایندینگ‌ها در <<_libgit2_bindings>> هم اشاره کرده‌ایم.
 
-==== Advanced Functionality
+==== Advanced Functionality (قابلیت‌های پیشرفته)
 
-Libgit2 has a couple of capabilities that are outside the scope of core Git.
-One example is pluggability: Libgit2 allows you to provide custom "`backends`" for several types of operation, so you can store things in a different way than stock Git does.
-Libgit2 allows custom backends for configuration, ref storage, and the object database, among other things.
+Libgit2 چند قابلیت دارد که فراتر از محدودهٔ اصلی گیت هستند.
+یک مثال، افزونه‌پذیری است: Libgit2 به شما اجازه می‌دهد برای چند نوع عملیات، «backend»های سفارشی فراهم کنید، تا بتوانید داده‌ها را به شکلی متفاوت از گیت استاندارد ذخیره کنید.
+Libgit2 امکان تعریف backendهای سفارشی برای پیکربندی، ذخیرهٔ ref و پایگاه دادهٔ آبجکت‌ها و موارد دیگر را فراهم می‌کند.
 
-Let's take a look at how this works.
-The code below is borrowed from the set of backend examples provided by the Libgit2 team (which can be found at https://github.com/libgit2/libgit2-backends[^]).
-Here's how a custom backend for the object database is set up:
+بیایید ببینیم این چگونه کار می‌کند.
+کد زیر از مجموعه مثال‌های backend که تیم Libgit2 ارائه داده‌اند گرفته شده است (قابل مشاهده در https://github.com/libgit2/libgit2-backends[^]).
+در اینجا نحوهٔ راه‌اندازی یک backend سفارشی برای پایگاه دادهٔ آبجکت‌ها نشان داده شده است:
 
 [source,c]
 ----
@@ -133,16 +133,16 @@ error = git_repository_open(&repo, "some-path");
 error = git_repository_set_odb(repo, odb); // <4>
 ----
 
-_Note that errors are captured, but not handled. We hope your code is better than ours._
+_توجه: خطاها گرفته می‌شوند ولی رسیدگی نمی‌شوند. امیدواریم کد شما بهتر از ما باشد._
 
-<1> Initialize an empty object database (ODB) "`frontend,`" which will act as a container for the "`backends`" which are the ones doing the real work.
-<2> Initialize a custom ODB backend.
-<3> Add the backend to the frontend.
-<4> Open a repository, and set it to use our ODB to look up objects.
+<1> یک «frontend» خالی برای پایگاه دادهٔ آبجکت (ODB) مقداردهی اولیه کنید که به عنوان ظرفی برای «backend»ها عمل می‌کند—همان backendها هستند که کار واقعی را انجام می‌دهند.
+<2> یک backend سفارشی برای ODB مقداردهی اولیه کنید.
+<3> backend را به frontend اضافه کنید.
+<4> یک مخزن باز کنید و آن را طوری تنظیم کنید که از ODB ما برای جستجوی آبجکت‌ها استفاده کند.
 
-But what is this `git_odb_backend_mine` thing?
-Well, that's the constructor for your own ODB implementation, and you can do whatever you want in there, so long as you fill in the `git_odb_backend` structure properly.
-Here's what it _could_ look like:
+اما این git_odb_backend_mine چیست؟
+این تابع سازندهٔ پیاده‌سازی ODB مخصوص شماست، و شما می‌توانید هر کاری که می‌خواهید در آن انجام دهید، تا وقتی که ساختار git_odb_backend را به‌درستی پر کنید.
+ممکن است شبیه چیزی شبیه به این باشد:
 
 [source,c]
 ----
@@ -172,40 +172,40 @@ int git_odb_backend_mine(git_odb_backend **backend_out, /*…*/)
 }
 ----
 
-The subtlest constraint here is that ``my_backend_struct```'s first member must be a ``git_odb_backend`` structure; this ensures that the memory layout is what the Libgit2 code expects it to be.
-The rest of it is arbitrary; this structure can be as large or small as you need it to be.
+محفوظ‌ترین قید این است که اولین عضو ساختار my_backend_struct باید یک ساختار git_odb_backend باشد؛ این تضمین می‌کند که چیدمان حافظه همان چیزی است که کد Libgit2 انتظار دارد.
+باقی ساختار دلخواه است؛ این ساختار می‌تواند به هر اندازه‌ای که لازم دارید بزرگ یا کوچک باشد.
 
-The initialization function allocates some memory for the structure, sets up the custom context, and then fills in the members of the `parent` structure that it supports.
-Take a look at the `include/git2/sys/odb_backend.h` file in the Libgit2 source for a complete set of call signatures; your particular use case will help determine which of these you'll want to support.
+ تابع مقداردهی اولیه مقداری حافظه برای ساختار رزرو می‌کند، زمینهٔ سفارشی را راه‌اندازی می‌نماید و سپس اعضای ساختار `parent` که پشتیبانی می‌کند را پر می‌کند.
+برای مجموعهٔ کامل امضاهای فراخوانی‌ها، فایل `include/git2/sys/odb_backend.h` در سورس Libgit2 را ببینید؛ مورد استفادهٔ خاص شما تعیین خواهد کرد کدام یک از این‌ها را می‌خواهید پشتیبانی کنید.
 
 [[_libgit2_bindings]]
-==== Other Bindings
+==== Other Bindings (بایندینگ‌های دیگر)
 
-Libgit2 has bindings for many languages.
-Here we show a small example using a few of the more complete bindings packages as of this writing; libraries exist for many other languages, including C++, Go, Node.js, Erlang, and the JVM, all in various stages of maturity.
-The official collection of bindings can be found by browsing the repositories at https://github.com/libgit2[^].
-The code we'll write will return the commit message from the commit eventually pointed to by HEAD (sort of like `git log -1`).
+Libgit2 برای زبان‌های زیادی رابط ارائه کرده است.
+در اینجا یک مثال کوتاه نشان می‌دهیم که از چند مورد از بسته‌های رابط کامل‌تر در زمان نگارش استفاده می‌کند؛ کتابخانه‌هایی برای زبان‌های دیگری مانند C++، Go، Node.js، Erlang و JVM نیز وجود دارند که هر یک در مراحل مختلفی از تکامل قرار دارند.
+مجموعهٔ رسمی رابط‌ها را می‌توانید با مرور مخازن در https://github.com/libgit2[^] بیابید.
+کدی که خواهیم نوشت پیام کمیت (commit message) را از کمیتی باز می‌گرداند که در نهایت HEAD به آن اشاره می‌کند (تا حدی مشابه `git log -1`).
 
-===== LibGit2Sharp
+===== LibGit2Sharp (بایندینگ گیت برای .NET)
 
 (((.NET)))(((C#)))(((Mono)))
-If you're writing a .NET or Mono application, LibGit2Sharp (https://github.com/libgit2/libgit2sharp[^]) is what you're looking for.
-The bindings are written in C#, and great care has been taken to wrap the raw Libgit2 calls with native-feeling CLR APIs.
-Here's what our example program looks like:
+اگر در حال نوشتن یک برنامهٔ .NET یا Mono هستید، LibGit2Sharp (https://github.com/libgit2/libgit2sharp[^]) همان چیزی است که به دنبالش هستید.
+این رابط‌ها به زبان C# نوشته شده‌اند و دقت زیادی در پوشش‌دهی فراخوانی‌های خام Libgit2 با APIهای بومی‌تر CLR به‌کار رفته است.
+برنامهٔ نمونهٔ ما به این شکل است:
 
 [source,csharp]
 ----
 new Repository(@"C:\path\to\repo").Head.Tip.Message;
 ----
 
-For desktop Windows applications, there's even a NuGet package that will help you get started quickly.
+برای برنامه‌های دسکتاپ ویندوز، حتی یک بستهٔ NuGet وجود دارد که به شما کمک می‌کند سریع شروع کنید.
 
-===== objective-git
+===== objective-git (بایندینگ گیت برای Objective-C ✅)
 
 (((Apple)))(((Objective-C)))(((Cocoa)))
-If your application is running on an Apple platform, you're likely using Objective-C as your implementation language.
-Objective-Git (https://github.com/libgit2/objective-git[^]) is the name of the Libgit2 bindings for that environment.
-The example program looks like this:
+اگر برنامهٔ شما روی پلتفرم‌های اپل اجرا می‌شود، احتمالاً از Objective-C به‌عنوان زبان پیاده‌سازی استفاده می‌کنید.
+Objective-Git (https://github.com/libgit2/objective-git[^]) نام رابط‌های Libgit2 برای آن محیط است.
+برنامهٔ نمونه به این شکل است:
 
 [source,objc]
 ----
@@ -214,13 +214,13 @@ GTRepository *repo =
 NSString *msg = [[[repo headReferenceWithError:NULL] resolvedTarget] message];
 ----
 
-Objective-git is fully interoperable with Swift, so don't fear if you've left Objective-C behind.
+Objective-git کاملاً با Swift قابل‌تعامل است، بنابراین اگر Objective-C را کنار گذاشته‌اید نگران نباشید.
 
-===== pygit2
+===== pygit2 (بایندینگ گیت برای پایتون)
 
 (((Python)))
-The bindings for Libgit2 in Python are called Pygit2, and can be found at https://www.pygit2.org[^].
-Our example program:
+رابط‌های Libgit2 برای پایتون با نام Pygit2 شناخته می‌شوند و در https://www.pygit2.org[^] در دسترس‌اند.
+برنامهٔ نمونهٔ ما:
 
 [source,python]
 ----
@@ -230,8 +230,8 @@ pygit2.Repository("/path/to/repo") # open repository
     .message                       # read the message
 ----
 
-==== Further Reading
+==== Further Reading (مطالعهٔ بیشتر)
 
-Of course, a full treatment of Libgit2's capabilities is outside the scope of this book.
-If you want more information on Libgit2 itself, there's API documentation at https://libgit2.github.com/libgit2[^], and a set of guides at https://libgit2.github.com/docs[^].
-For the other bindings, check the bundled README and tests; there are often small tutorials and pointers to further reading there.
+البته، بررسی کامل قابلیت‌های Libgit2 خارج از دامنهٔ این کتاب است.
+اگر می‌خواهید اطلاعات بیشتری دربارهٔ خود Libgit2 به‌دست آورید، مستندات API آن در https://libgit2.github.com/libgit2 و مجموعه‌ای از راهنماها در https://libgit2.github.com/docs در دسترس هستند.
+برای دیگر بایندینگ‌ها، فایل README همراه و تست‌ها را بررسی کنید؛ معمولاً در آن‌ها آموزش‌های کوتاه و ارجاع‌هایی برای مطالعهٔ بیشتر پیدا می‌شود.


### PR DESCRIPTION
This pull request updates several sections of the book to provide Persian translations and improve clarity for descriptions of Git libraries and command-line usage. The changes focus on translating content, clarifying technical explanations, and enhancing the readability of examples for Dulwich, go-git, JGit, and command-line Git integration.

**Translations and Explanations of Git Libraries:**

* Added Persian translations and clarified the introduction and advanced features for the `go-git` library, including extensibility, pluggable storage, flexible filesystem abstraction, and HTTP client customization. [[1]](diffhunk://#diff-847c1af011164f0a159854782523e2db72a195b5ebfce39ba4bb94b8c9286226L1-R10) [[2]](diffhunk://#diff-847c1af011164f0a159854782523e2db72a195b5ebfce39ba4bb94b8c9286226L41-R44) [[3]](diffhunk://#diff-847c1af011164f0a159854782523e2db72a195b5ebfce39ba4bb94b8c9286226L53-R59)
* Translated and improved the explanation of the `Dulwich` Python library, separating plumbing and porcelain APIs and updating example descriptions. [[1]](diffhunk://#diff-7d6c8ee1c2afa9744404c7fa413e802f200ceca7c1701d2d90644f411c0caea9L1-R11) [[2]](diffhunk://#diff-7d6c8ee1c2afa9744404c7fa413e802f200ceca7c1701d2d90644f411c0caea9L28-R28) [[3]](diffhunk://#diff-7d6c8ee1c2afa9744404c7fa413e802f200ceca7c1701d2d90644f411c0caea9L40-R42)
* Translated and expanded the section on the `JGit` Java library, covering setup (Maven and manual), plumbing API usage, error handling, and porcelain API examples. [[1]](diffhunk://#diff-6dd332357d6711f0cc77737694f04482e747806150034a8dc6f7640bcd12db48L1-R11) [[2]](diffhunk://#diff-6dd332357d6711f0cc77737694f04482e747806150034a8dc6f7640bcd12db48L22-R42) [[3]](diffhunk://#diff-6dd332357d6711f0cc77737694f04482e747806150034a8dc6f7640bcd12db48L55-R61) [[4]](diffhunk://#diff-6dd332357d6711f0cc77737694f04482e747806150034a8dc6f7640bcd12db48L91-R120) [[5]](diffhunk://#diff-6dd332357d6711f0cc77737694f04482e747806150034a8dc6f7640bcd12db48L130-R130)

**Translation and Clarification of Command-line Git Usage:**

* Translated and clarified the section on using Git from the command line, highlighting pros and cons such as output parsing, error recovery, and process management.